### PR TITLE
Add promotional copy for homepage feature cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,9 +190,9 @@
                     />
                     <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
                     <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Studio Life</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Inside the Istanbul Atelier</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Collaborative spaces that bring craft, technology, and dialogue together.</p>
+                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Kampanya</p>
+                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Yarın Tasarlanan Mekânlar</h3>
+                        <p class="mt-2 max-w-xs text-sm text-white/70">İstanbul stüdyomuzun enerjisini anlatan televizyon filmimiz, AMA imzası taşıyan kentsel yaşam vizyonunu vitrine çıkarıyor.</p>
                     </div>
                 </article>
                 <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
@@ -203,9 +203,9 @@
                     />
                     <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
                     <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Perspective</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Resilient Cultural Landscapes</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Design strategies that respond to climate while celebrating local narratives.</p>
+                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Outdoor Serisi</p>
+                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Geceyi Aydınlatan Pavyonlar</h3>
+                        <p class="mt-2 max-w-xs text-sm text-white/70">Riyad'ın çöl ışığını yakalayan 360° LED totemlerimiz, kamusal alan kampanyasında tasarım ve hikâyeyi tek sahnede buluşturuyor.</p>
                     </div>
                 </article>
                 <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
@@ -216,9 +216,9 @@
                     />
                     <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
                     <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Global Practice</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Elevating Urban Skylines</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Hybrid towers that balance hospitality, culture, and public experience.</p>
+                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Dijital Lansman</p>
+                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Gökyüzüne Uzanan Marka Manifestosu</h3>
+                        <p class="mt-2 max-w-xs text-sm text-white/70">Metaverse turumuz, imza kule portföyümüzü artırılmış gerçeklikte gezdirerek AMA'nın geleceğin kentlerini nasıl kurduğunu duyuruyor.</p>
                     </div>
                 </article>
             </div>


### PR DESCRIPTION
## Summary
- replace placeholder card copy with a promotional advertising concept for the architecture studio
- highlight campaign, outdoor, and digital launch narratives tailored to AMA's brand voice

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d53a8c5f108325b25812249027112e