### PR TITLE
Reframe hero and feature copy around AI-led studio visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,13 +59,13 @@
                 <div class="flex h-full w-full transition-transform duration-700 ease-in-out" id="carousel">
                     <div
                         class="carousel-item relative h-full w-full"
-                        data-category="Residential"
-                        data-description="Revealing the first glimpses of life in a serene coastal retreat where refined lines meet the Aegean horizon."
-                        data-location="Bodrum, TR"
-                        data-title="Nef Reserve Gölköy"
+                        data-category="Stüdyo Sunumu"
+                        data-description="AMA'nın yeni ofis planı, doğal ışığı ve ortak alanları öne çıkaran AI destekli görsellerle anlaşılır biçimde tanıtılıyor."
+                        data-location="Merkez Stüdyo"
+                        data-title="Camla Açılan Çalışma Alanı"
                     >
                         <img
-                            alt="Nef Reserve Gölköy"
+                            alt="Camla Açılan Çalışma Alanı"
                             class="h-full w-full object-cover"
                             src="https://lh3.googleusercontent.com/aida-public/AB6AXuBY3ViKq1aw3yXDhhfDzgn7d0Vnt9jkYwQLGkJo0WUnOSAcz06Acijs0rfUd0xb9zxwwedHo2UBB6vTEREgApkNX5S4pv1vRV9RH5B9nCgadZSPz8edx5Oegr7Vkl61cWtBT8vpoeYYONTO_1dQasguKJknaYBs5x-ksJA5c-Xwg-FAO92cpnoXersUR8s4cA3gg84RtdesgofL6GVefDsHtJABqFzz-Eiljg6sCLAXqvHOLTd-bZt5Avma1ITGxYiogtxhLn5cU3s"
                         />
@@ -73,13 +73,13 @@
                     </div>
                     <div
                         class="carousel-item relative h-full w-full"
-                        data-category="Cultural"
-                        data-description="A sculpted public space in Riyadh that folds desert light into a contemporary urban experience."
-                        data-location="Riyadh, SA"
-                        data-title="Al Sahra Pavilion"
+                        data-category="Proje Tanıtımı"
+                        data-description="Lobi ve bekleme salonu için hazırlanan AI görselleri, günlük akışı anlatan sıcak ışık senaryolarıyla destekleniyor."
+                        data-location="Giriş Holü"
+                        data-title="Yumuşak Işıkta Karşılama"
                     >
                         <img
-                            alt="Architectural detail of a modern building"
+                            alt="Yumuşak Işıkta Karşılama"
                             class="h-full w-full object-cover"
                             src="https://lh3.googleusercontent.com/aida-public/AB6AXuDywh5KHJIrXp4s52K1q899PeRE9lFxVweHMW2m5xVN5GAmy9rXujubUdVBDEb-52DZCJp8ESyuMVD_iEpICFtvVL6QsGb93VmuZxZS2PJB6fJAIbiNy8gFLVVeLF4ljljtdkYfvQ4Zth5632bC7EwePczCSU-byb1tPIHSyUcXztEFgLEIO51I97KC8pNhm7AiIDRl0eeST75VN8H9S7ncLlFfgKAAeySs12gW0IO-bRgtDVQ4sq1_n5jqPeqOZDy0fEuyZiJHm0"
                         />
@@ -87,13 +87,13 @@
                     </div>
                     <div
                         class="carousel-item relative h-full w-full"
-                        data-category="Hospitality"
-                        data-description="An immersive interior landscape that blurs the threshold between nature, art, and crafted comfort."
-                        data-location="Istanbul, TR"
-                        data-title="Aether Residence"
+                        data-category="Gece Görselleştirmesi"
+                        data-description="Şehir panoraması, ofis cephesinin gece aydınlatmasını AI tabanlı renderlarla gerçekçi bir şekilde gösteriyor."
+                        data-location="Kent Silueti"
+                        data-title="Akşam Cephesi"
                     >
                         <img
-                            alt="Interior of a modern house"
+                            alt="Akşam Cephesi"
                             class="h-full w-full object-cover"
                             src="https://lh3.googleusercontent.com/aida-public/AB6AXuAGbCFIA5CK9Pt4bi0fEdIphWGRzysF0RACqcAQrhCRIPHNhljJIo6DXOsFA5HPMoO8zXERyza-Pl9_e2OnZ-xhgdR2DLkBdVZYKQhOU427ZgDH9NZowetlX5r8f0oCfikqMJkrSuabc9Pi1C7s9zIfz3eUbptgsAll8sluvlI2-86xYefKmDEughe06TuGjVz0RSjVQXHL9l_ze9uidcyYGPuDr_t-CPGqqwi2ZkM7eIn8BIcOvFtdYcURahWa7XoWGf4HO3kRaHY"
                         />
@@ -123,12 +123,12 @@
 
             <div class="relative z-20 flex h-full flex-col justify-end px-8 pb-24 md:px-20">
                 <div class="pointer-events-auto max-w-3xl space-y-6">
-                    <p class="text-xs uppercase tracking-[0.55em] text-white/60" id="slide-category">Residential</p>
+                    <p class="text-xs uppercase tracking-[0.55em] text-white/60" id="slide-category">AI Vizyonu</p>
                     <h1 class="text-4xl font-display font-light leading-[1.1] text-white transition-all duration-500 md:text-6xl" id="slide-title">
-                        Nef Reserve Gölköy
+                        Işığın İçinde Yüzen Atölye
                     </h1>
                     <p class="text-sm text-white/70 md:text-base" id="slide-description">
-                        Revealing the first glimpses of life in a serene coastal retreat where refined lines meet the Aegean horizon.
+                        AMA Vision Lab'in yapay zekâ ile kurguladığı eterik çalışma adaları, stüdyonun sınır tanımayan mekân dilini ilk bakışta hissettiriyor.
                     </p>
                 </div>
                 <div class="pointer-events-auto mt-12 flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
@@ -137,7 +137,7 @@
                         <span class="font-display text-sm text-white" id="slide-index">01</span>
                         <span class="text-white/40">/</span>
                         <span class="font-display text-sm text-white/70" id="slide-total">03</span>
-                        <span class="text-white/50" id="slide-location">Bodrum, TR</span>
+                        <span class="text-white/50" id="slide-location">AMA Vision Lab</span>
                     </div>
                     <div class="flex items-center gap-6">
                         <div class="relative h-0.5 w-32 overflow-hidden bg-white/25">
@@ -172,53 +172,70 @@
         <section class="bg-background-dark px-8 py-20 text-primary md:px-20">
             <div class="flex flex-col gap-12 md:flex-row md:items-end md:justify-between">
                 <div>
-                    <p class="text-xs uppercase tracking-[0.55em] text-accent">Featured Works</p>
-                    <h2 class="mt-4 max-w-2xl text-3xl font-display text-white md:text-5xl">Stories from Alper Morkoç Architecture</h2>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent">Vision Lab</p>
+                    <h2 class="mt-4 max-w-2xl text-3xl font-display text-white md:text-5xl">AMA'nın Yapay Zekâ ile Hazırlanan Tanıtımı</h2>
                 </div>
                 <div class="max-w-xl text-sm text-gray-400">
                     <p>
-                        A curated selection of places, people, and crafted experiences that define the studio's multidimensional practice across the globe.
+                        Henüz uygulama aşamasına geçmeyen projelerimizi, AI destekli görsel üretimlerle sade ve anlaşılır şekilde sunuyoruz. Her görsel, ofisimizin yaklaşımını potansiyel iş ortaklarına açık bir dille anlatmayı amaçlıyor.
                     </p>
+                    <div class="mt-6 grid grid-cols-3 gap-3 text-[0px]">
+                        <img
+                            alt="AI ile hazırlanmış ofis lobisi görseli"
+                            class="h-24 w-full rounded-sm object-cover"
+                            src="https://images.unsplash.com/photo-1529429617124-aee575b5dbb3?auto=format&fit=crop&w=400&q=80"
+                        />
+                        <img
+                            alt="AI ile oluşturulan toplantı alanı renderı"
+                            class="h-24 w-full rounded-sm object-cover"
+                            src="https://images.unsplash.com/photo-1670604606316-3f97b0623e58?auto=format&fit=crop&w=400&q=80"
+                        />
+                        <img
+                            alt="AI ile tasarlanmış cephe aydınlatma görseli"
+                            class="h-24 w-full rounded-sm object-cover"
+                            src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=400&q=80"
+                        />
+                    </div>
                 </div>
             </div>
             <div class="mt-16 grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
                 <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
                     <img
-                        alt="Design team in conversation"
+                        alt="Yapay zekâ ile kurgulanmış ışıklı toplantı salonu"
+                        class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
+                        src="https://images.unsplash.com/photo-1670604606316-3f97b0623e58?auto=format&fit=crop&w=1100&q=80"
+                    />
+                    <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
+                    <div class="absolute bottom-0 p-6">
+                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Studio Preview</p>
+                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Toplantı Salonu Planı</h3>
+                        <p class="mt-2 max-w-xs text-sm text-white/70">AI ile üretilen bu görsel, şeffaf paneller ve gün ışığı kurgusuyla stüdyonun toplantı düzenini basit ve net biçimde anlatıyor.</p>
+                    </div>
+                </article>
+                <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
+                    <img
+                        alt="Yapay zekâ tarafından tasarlanmış akışkan atrium"
                         class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
                         src="https://images.unsplash.com/photo-1529429617124-aee575b5dbb3?auto=format&fit=crop&w=1100&q=80"
                     />
                     <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
                     <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Studio Life</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Inside the Istanbul Atelier</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Collaborative spaces that bring craft, technology, and dialogue together.</p>
+                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Signature Render</p>
+                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Atrium Sunumu</h3>
+                        <p class="mt-2 max-w-xs text-sm text-white/70">Atrium bölümünün AI tabanlı renderı, ziyaretçi akışını ve ışık dağılımını projenin sunum dosyasında kullanılacak netlikte gösteriyor.</p>
                     </div>
                 </article>
                 <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
                     <img
-                        alt="Modern cultural pavilion"
+                        alt="Gece vakti neon çizgilere sahip şehir silueti"
                         class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                        src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1100&q=80"
+                        src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1100&q=80"
                     />
                     <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
                     <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Perspective</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Resilient Cultural Landscapes</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Design strategies that respond to climate while celebrating local narratives.</p>
-                    </div>
-                </article>
-                <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
-                    <img
-                        alt="High-rise skyline"
-                        class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                        src="https://images.unsplash.com/photo-1487956382158-bb926046304a?auto=format&fit=crop&w=1100&q=80"
-                    />
-                    <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
-                    <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Global Practice</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Elevating Urban Skylines</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Hybrid towers that balance hospitality, culture, and public experience.</p>
+                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Brand Film</p>
+                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Gece Cephe Görseli</h3>
+                        <p class="mt-2 max-w-xs text-sm text-white/70">Ofis cephesinin gece görünümü, AI ile üretilen ışık senaryolarıyla müşterilere sunumlarda kullanılmak üzere hazırlandı.</p>
                     </div>
                 </article>
             </div>


### PR DESCRIPTION
## Summary
- soften the hero carousel metadata with plain-language AI office descriptions that match the new titles
- add a compact AI visual gallery to the Vision Lab intro so the text section also showcases imagery
- rewrite the featured cards with straightforward explanations of the AI renders prepared for presentations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d53a8c5f108325b25812249027112e