### PR TITLE
Design AI concept panels for empty sections

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title>Contact — Alper Morkoç Architecture</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black/60 px-8 py-6 backdrop-blur-md md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white">Alper Morkoç</span> Architecture
+            </a>
+            <nav class="hidden items-center space-x-10 text-xs uppercase tracking-[0.45em] text-white/70 md:flex">
+                <a class="transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                <a class="transition-opacity hover:opacity-60" href="services.html">Services</a>
+                <a class="transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                <a class="transition-opacity hover:opacity-60" href="contact.html">Contact</a>
+            </nav>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" for="language-select">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="language-select"
+                >
+                    <option value="tr" selected>TR</option>
+                    <option value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="search-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">search</span>
+                    <span>Search</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="grid gap-16 md:grid-cols-[2fr,1fr]">
+            <div class="space-y-10">
+                <div
+                    aria-label="Stüdyo girişini anlatan AI görsel"
+                    class="ai-visual h-48 w-full"
+                    role="img"
+                    style="background-image: radial-gradient(circle at 22% 28%, rgba(255, 208, 158, 0.8) 0%, rgba(255, 208, 158, 0) 55%), radial-gradient(circle at 78% 68%, rgba(161, 218, 255, 0.6) 0%, rgba(161, 218, 255, 0) 48%), linear-gradient(150deg, #1a1c28, #0f1119 60%, #2d253a);"
+                ></div>
+                <p class="text-xs uppercase tracking-[0.55em] text-accent">İletişim</p>
+                <h1 class="text-4xl font-display text-white md:text-5xl">Bize Ulaşın</h1>
+                <p class="text-base text-white/70">
+                    Kampanya odaklı mimarlık sunumlarımız hakkında konuşmak veya AI görsel arşivimizi incelemek isterseniz, aşağıdaki formu doldurun.
+                    Henüz portföy paylaşmayan ekipler için hızlı başlangıç oturumu planlıyoruz.
+                </p>
+                <form class="space-y-6">
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label class="block text-xs uppercase tracking-[0.4em] text-white/60" for="contact-name">Ad Soyad</label>
+                            <input class="mt-2 w-full border border-white/15 bg-black/40 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none" id="contact-name" placeholder="Alper Morkoç" type="text"/>
+                        </div>
+                        <div>
+                            <label class="block text-xs uppercase tracking-[0.4em] text-white/60" for="contact-email">E-posta</label>
+                            <input class="mt-2 w-full border border-white/15 bg-black/40 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none" id="contact-email" placeholder="ornek@studio.com" type="email"/>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-xs uppercase tracking-[0.4em] text-white/60" for="contact-topic">Sunum İlgisi</label>
+                        <select class="mt-2 w-full border border-white/15 bg-black/40 p-3 text-sm text-white focus:border-white focus:outline-none" id="contact-topic">
+                            <option>Tanıtım kitabı hazırlığı</option>
+                            <option>AI görsel üretim workshop</option>
+                            <option>Dijital lansman seti</option>
+                            <option>Diğer</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-xs uppercase tracking-[0.4em] text-white/60" for="contact-message">Mesajınız</label>
+                        <textarea class="mt-2 h-32 w-full border border-white/15 bg-black/40 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none" id="contact-message" placeholder="Ekibinizin ihtiyacını kısaca anlatın..."></textarea>
+                    </div>
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Gönder
+                    </button>
+                </form>
+            </div>
+            <aside class="space-y-8 border border-white/10 bg-black/30 p-6">
+                <div
+                    aria-label="Galata stüdyo atmosferini anlatan AI görsel"
+                    class="ai-visual h-32 w-full"
+                    role="img"
+                    style="background-image: radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 48%), radial-gradient(circle at 78% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #131522, #1d1f31 58%, #302544);"
+                ></div>
+                <div class="space-y-2">
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">Stüdyo</p>
+                    <p class="text-sm text-white/70">Istanbul, Galata</p>
+                    <p class="text-sm text-white/60">Hafta içi 10:00 - 18:00 arası randevu ile görüşme sağlanır.</p>
+                </div>
+                <div class="space-y-2">
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">Telefon</p>
+                    <a class="text-sm text-white/70 transition hover:text-white" href="tel:+902122223344">+90 212 222 33 44</a>
+                </div>
+                <div class="space-y-2">
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">E-posta</p>
+                    <a class="text-sm text-white/70 transition hover:text-white" href="mailto:hello@amarchitecture.studio">hello@amarchitecture.studio</a>
+                </div>
+                <div class="space-y-2">
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">AI Görsel Arşivi</p>
+                    <p class="text-sm text-white/60">
+                        Sunum öncesi paylaşılacak örnek görseller için özel bir galeri bağlantısı oluşturuyoruz. Talep formunda belirtin.
+                    </p>
+                </div>
+            </aside>
+        </div>
+    </main>
+
+    <div
+        class="fixed inset-0 z-40 hidden opacity-0 bg-black/70 backdrop-blur-md transition-opacity"
+        id="search-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="search-title"
+    >
+        <div class="mx-auto mt-32 w-full max-w-2xl rounded-sm border border-white/15 bg-background-dark p-8 text-white shadow-2xl">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="search-title">Site İçi Arama</p>
+                    <h2 class="mt-3 text-3xl font-display text-white">Sunum İçeriklerinde Ara</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="search-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <form class="mt-8 space-y-4" role="search">
+                <label class="block text-sm uppercase tracking-[0.35em] text-white/60" for="search-input">Anahtar Kelime</label>
+                <input
+                    class="w-full border border-white/20 bg-black/40 p-4 text-base text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                    id="search-input"
+                    placeholder="Örn. iletişim, workshop"
+                    type="search"
+                />
+                <button
+                    class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20"
+                    type="submit"
+                >
+                    Arama Yap
+                </button>
+            </form>
+            <p class="mt-6 text-sm text-white/60">
+                Yapay zekâ ile üretilen görsel arşivimizi, başlık ve tema bazlı filtrelerle düzenliyoruz. İlk sürümde sonuç listesi taslağı gösterilir.
+            </p>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alper Morkoç Architecture</h3>
+                <p class="mt-3 text-sm text-gray-400">
+                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Join
+                    </button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p>© 2024 Alper Morkoç Architecture. All Rights Reserved.</p>
+        </div>
+    </footer>
+
+    <script>
+        const searchToggle = document.getElementById('search-toggle');
+        const searchPanel = document.getElementById('search-panel');
+        const searchClose = document.getElementById('search-close');
+        const searchInput = document.getElementById('search-input');
+        const languageSelect = document.getElementById('language-select');
+
+        const openSearchPanel = () => {
+            if (!searchPanel) return;
+            searchPanel.classList.remove('hidden');
+            searchPanel.classList.remove('opacity-0');
+            setTimeout(() => searchPanel.classList.add('opacity-100'), 10);
+            if (searchInput) {
+                setTimeout(() => searchInput.focus(), 120);
+            }
+        };
+
+        const closeSearchPanel = () => {
+            if (!searchPanel) return;
+            searchPanel.classList.remove('opacity-100');
+            searchPanel.classList.add('opacity-0');
+            setTimeout(() => searchPanel.classList.add('hidden'), 180);
+        };
+
+        if (searchToggle) {
+            searchToggle.addEventListener('click', openSearchPanel);
+        }
+
+        if (searchClose) {
+            searchClose.addEventListener('click', closeSearchPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && searchPanel && !searchPanel.classList.contains('hidden')) {
+                closeSearchPanel();
+            }
+        });
+
+        if (searchPanel) {
+            searchPanel.addEventListener('click', (event) => {
+                if (event.target === searchPanel) {
+                    closeSearchPanel();
+                }
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="dark" lang="en">
+<html class="dark" lang="tr">
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
@@ -50,6 +50,25 @@
         .reveal {
             animation: reveal 0.6s ease forwards;
         }
+
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
     </style>
 </head>
 <body class="bg-background-dark text-primary font-body antialiased">
@@ -59,43 +78,43 @@
                 <div class="flex h-full w-full transition-transform duration-700 ease-in-out" id="carousel">
                     <div
                         class="carousel-item relative h-full w-full"
-                        data-category="Residential"
-                        data-description="Revealing the first glimpses of life in a serene coastal retreat where refined lines meet the Aegean horizon."
-                        data-location="Bodrum, TR"
-                        data-title="Nef Reserve Gölköy"
+                        data-category="Kampanya Vitrini"
+                        data-description="Gün ışığıyla nefes alan çalışma adaları, yeni ofisimizin sakin ama üretken temposunu sahne ışığı altına taşıyor."
+                        data-location="Merkez Stüdyo"
+                        data-title="Gün Doğumu Stüdyo Kurgusu"
                     >
                         <img
-                            alt="Nef Reserve Gölköy"
+                            alt="Cam duvarlarla çevrili aydınlık çalışma alanı"
                             class="h-full w-full object-cover"
-                            src="https://lh3.googleusercontent.com/aida-public/AB6AXuBY3ViKq1aw3yXDhhfDzgn7d0Vnt9jkYwQLGkJo0WUnOSAcz06Acijs0rfUd0xb9zxwwedHo2UBB6vTEREgApkNX5S4pv1vRV9RH5B9nCgadZSPz8edx5Oegr7Vkl61cWtBT8vpoeYYONTO_1dQasguKJknaYBs5x-ksJA5c-Xwg-FAO92cpnoXersUR8s4cA3gg84RtdesgofL6GVefDsHtJABqFzz-Eiljg6sCLAXqvHOLTd-bZt5Avma1ITGxYiogtxhLn5cU3s"
+                            src="https://images.unsplash.com/photo-1497366216548-37526070297c?auto=format&fit=crop&w=1600&q=80"
                         />
                         <div class="absolute inset-0 bg-gradient-to-r from-black/80 via-black/30 to-black/40"></div>
                     </div>
                     <div
                         class="carousel-item relative h-full w-full"
-                        data-category="Cultural"
-                        data-description="A sculpted public space in Riyadh that folds desert light into a contemporary urban experience."
-                        data-location="Riyadh, SA"
-                        data-title="Al Sahra Pavilion"
+                        data-category="Mekân Lansmanı"
+                        data-description="Doğal taş ve yumuşak aydınlatma birlikteliği, giriş holünü markamızın sıcak tonlarıyla buluşturan davetkâr bir sahneye dönüştürüyor."
+                        data-location="Giriş Holü"
+                        data-title="Yumuşak Işıkta Karşılama"
                     >
                         <img
-                            alt="Architectural detail of a modern building"
+                            alt="Ahşap detaylara sahip sıcak karşılaşma alanı"
                             class="h-full w-full object-cover"
-                            src="https://lh3.googleusercontent.com/aida-public/AB6AXuDywh5KHJIrXp4s52K1q899PeRE9lFxVweHMW2m5xVN5GAmy9rXujubUdVBDEb-52DZCJp8ESyuMVD_iEpICFtvVL6QsGb93VmuZxZS2PJB6fJAIbiNy8gFLVVeLF4ljljtdkYfvQ4Zth5632bC7EwePczCSU-byb1tPIHSyUcXztEFgLEIO51I97KC8pNhm7AiIDRl0eeST75VN8H9S7ncLlFfgKAAeySs12gW0IO-bRgtDVQ4sq1_n5jqPeqOZDy0fEuyZiJHm0"
+                            src="https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1600&q=80"
                         />
                         <div class="absolute inset-0 bg-gradient-to-r from-black/80 via-black/40 to-black/20"></div>
                     </div>
                     <div
                         class="carousel-item relative h-full w-full"
-                        data-category="Hospitality"
-                        data-description="An immersive interior landscape that blurs the threshold between nature, art, and crafted comfort."
-                        data-location="Istanbul, TR"
-                        data-title="Aether Residence"
+                        data-category="Gece Senaryosu"
+                        data-description="Kentin ritmine eşlik eden cephe ışıkları, ofisimizin akşam saatlerindeki rafine duruşunu panoramaya taşıyor."
+                        data-location="Kent Silueti"
+                        data-title="Akşam Cephesi"
                     >
                         <img
-                            alt="Interior of a modern house"
+                            alt="Gece ışıklarıyla parlayan ofis cephesi"
                             class="h-full w-full object-cover"
-                            src="https://lh3.googleusercontent.com/aida-public/AB6AXuAGbCFIA5CK9Pt4bi0fEdIphWGRzysF0RACqcAQrhCRIPHNhljJIo6DXOsFA5HPMoO8zXERyza-Pl9_e2OnZ-xhgdR2DLkBdVZYKQhOU427ZgDH9NZowetlX5r8f0oCfikqMJkrSuabc9Pi1C7s9zIfz3eUbptgsAll8sluvlI2-86xYefKmDEughe06TuGjVz0RSjVQXHL9l_ze9uidcyYGPuDr_t-CPGqqwi2ZkM7eIn8BIcOvFtdYcURahWa7XoWGf4HO3kRaHY"
+                            src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80"
                         />
                         <div class="absolute inset-0 bg-gradient-to-r from-black/85 via-black/40 to-black/10"></div>
                     </div>
@@ -104,31 +123,45 @@
             <div class="pointer-events-none absolute inset-0 bg-gradient-to-b from-black via-black/10 to-background-dark"></div>
 
             <header class="absolute top-0 left-0 right-0 z-30 px-8 py-10 md:px-16">
-                <div class="flex items-center justify-between">
+                <div class="flex items-center justify-between gap-8">
                     <div class="text-sm font-display uppercase tracking-[0.6em] text-white/80">
                         <span class="font-bold text-white">Alper Morkoç</span> Architecture
                     </div>
                     <nav class="hidden items-center space-x-10 text-xs uppercase tracking-[0.45em] text-white/70 md:flex">
-                        <a class="transition-opacity hover:opacity-60" href="#">Studio</a>
-                        <a class="transition-opacity hover:opacity-60" href="#">Projects</a>
-                        <a class="transition-opacity hover:opacity-60" href="#">Insights</a>
-                        <a class="transition-opacity hover:opacity-60" href="#">Contact</a>
+                        <a class="transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                        <a class="transition-opacity hover:opacity-60" href="services.html">Services</a>
+                        <a class="transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                        <a class="transition-opacity hover:opacity-60" href="contact.html">Contact</a>
                     </nav>
-                    <button class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60">
-                        <span class="material-icons text-base">search</span>
-                        <span>Search</span>
-                    </button>
+                    <div class="flex items-center gap-4">
+                        <label class="sr-only" for="language-select">Dil Seçimi</label>
+                        <select
+                            class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                            id="language-select"
+                        >
+                            <option value="tr" selected>TR</option>
+                            <option value="en">EN</option>
+                        </select>
+                        <button
+                            class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                            id="search-toggle"
+                            type="button"
+                        >
+                            <span class="material-icons text-base">search</span>
+                            <span>Search</span>
+                        </button>
+                    </div>
                 </div>
             </header>
 
             <div class="relative z-20 flex h-full flex-col justify-end px-8 pb-24 md:px-20">
                 <div class="pointer-events-auto max-w-3xl space-y-6">
-                    <p class="text-xs uppercase tracking-[0.55em] text-white/60" id="slide-category">Residential</p>
+                    <p class="text-xs uppercase tracking-[0.55em] text-white/60" id="slide-category">Kampanya Vitrini</p>
                     <h1 class="text-4xl font-display font-light leading-[1.1] text-white transition-all duration-500 md:text-6xl" id="slide-title">
-                        Nef Reserve Gölköy
+                        Gün Doğumu Stüdyo Kurgusu
                     </h1>
                     <p class="text-sm text-white/70 md:text-base" id="slide-description">
-                        Revealing the first glimpses of life in a serene coastal retreat where refined lines meet the Aegean horizon.
+                        Gün ışığıyla nefes alan çalışma adaları, yeni ofisimizin sakin ama üretken temposunu sahne ışığı altına taşıyor.
                     </p>
                 </div>
                 <div class="pointer-events-auto mt-12 flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
@@ -137,7 +170,7 @@
                         <span class="font-display text-sm text-white" id="slide-index">01</span>
                         <span class="text-white/40">/</span>
                         <span class="font-display text-sm text-white/70" id="slide-total">03</span>
-                        <span class="text-white/50" id="slide-location">Bodrum, TR</span>
+                        <span class="text-white/50" id="slide-location">Merkez Stüdyo</span>
                     </div>
                     <div class="flex items-center gap-6">
                         <div class="relative h-0.5 w-32 overflow-hidden bg-white/25">
@@ -172,58 +205,119 @@
         <section class="bg-background-dark px-8 py-20 text-primary md:px-20">
             <div class="flex flex-col gap-12 md:flex-row md:items-end md:justify-between">
                 <div>
-                    <p class="text-xs uppercase tracking-[0.55em] text-accent">Featured Works</p>
-                    <h2 class="mt-4 max-w-2xl text-3xl font-display text-white md:text-5xl">Stories from Alper Morkoç Architecture</h2>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent">Stüdyo Profili</p>
+                    <h2 class="mt-4 max-w-2xl text-3xl font-display text-white md:text-5xl">AMA'nın Butik Mimarlık Yaklaşımı</h2>
                 </div>
                 <div class="max-w-xl text-sm text-gray-400">
                     <p>
-                        A curated selection of places, people, and crafted experiences that define the studio's multidimensional practice across the globe.
+                        Henüz uygulama aşamasına geçmeyen projelerimizi, yalın anlatımlı sunumlarla ve detaylı maket çalışmalarıyla paylaşıyoruz. Hazırladığımız kampanya görselleri, ofisimizin ölçekli düşünme becerisini ve samimi iletişim dilini kısa tanıtım metinleriyle birlikte ortaya koymayı hedefliyor.
+                    </p>
+                    <div class="mt-6 grid grid-cols-3 gap-3 text-[0px]">
+                        <div
+                            aria-label="Butik ofis lobisini gösteren AI konsept"
+                            class="ai-visual h-24"
+                            role="img"
+                            style="background-image: radial-gradient(circle at 20% 30%, rgba(255, 209, 147, 0.8) 0%, rgba(255, 209, 147, 0) 55%), radial-gradient(circle at 80% 10%, rgba(255, 137, 94, 0.6) 0%, rgba(255, 137, 94, 0) 45%), linear-gradient(135deg, #2a2a3a, #161620 55%, #1f2e45);"
+                        ></div>
+                        <div
+                            aria-label="Toplantı alanı için hazırlanan AI illüstrasyon"
+                            class="ai-visual h-24"
+                            role="img"
+                            style="background-image: radial-gradient(circle at 75% 25%, rgba(144, 201, 255, 0.7) 0%, rgba(144, 201, 255, 0) 50%), radial-gradient(circle at 15% 75%, rgba(255, 255, 255, 0.15) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(140deg, #1c2538, #10141f 60%, #243046);"
+                        ></div>
+                        <div
+                            aria-label="Gece cephe atmosferi için AI konsepti"
+                            class="ai-visual h-24"
+                            role="img"
+                            style="background-image: radial-gradient(circle at 30% 70%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), radial-gradient(circle at 80% 30%, rgba(255, 184, 212, 0.55) 0%, rgba(255, 184, 212, 0) 55%), linear-gradient(160deg, #101421, #1c1f31 55%, #2f2445);"
+                        ></div>
+                    </div>
+                </div>
+            </div>
+            <div class="mt-16 grid grid-cols-1 gap-10 md:grid-cols-3">
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="AI ile oluşturulmuş kampanya akışı eskizi"
+                        class="ai-visual h-36 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 20% 20%, rgba(255, 199, 141, 0.85) 0%, rgba(255, 199, 141, 0) 55%), radial-gradient(circle at 80% 80%, rgba(255, 119, 119, 0.45) 0%, rgba(255, 119, 119, 0) 50%), linear-gradient(145deg, #1f1f2e, #101019 60%, #2d2539);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">Kampanya Rehberi</p>
+                    <h3 class="text-2xl font-display text-white">Tanıtım Akışları</h3>
+                    <p class="text-sm text-white/70">
+                        Lobi, çalışma alanı ve gece cephesi sahnelerini sıralayan akış şemaları hazırlıyoruz.
+                        Boş kalan sayfalar, stüdyoda ürettiğimiz AI eskizleriyle dolduruluyor ve metinlerin tonu ile uyumlu kalıyor.
+                    </p>
+                </div>
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Sunum paketleri için AI ışık denemesi"
+                        class="ai-visual h-36 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 25% 65%, rgba(161, 218, 255, 0.7) 0%, rgba(161, 218, 255, 0) 55%), radial-gradient(circle at 80% 30%, rgba(255, 210, 162, 0.5) 0%, rgba(255, 210, 162, 0) 45%), linear-gradient(160deg, #1a1f2c, #0e111b 58%, #26324a);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">AI Görsel Dizisi</p>
+                    <h3 class="text-2xl font-display text-white">Sunum Paketleri</h3>
+                    <p class="text-sm text-white/70">
+                        Henüz proje üretmeyen ekipler için render, kolaj ve detaylı kesit denemeleri yapıyoruz.
+                        AI görselleri, sunum dosyasındaki boş bölümlere yerleşecek şekilde ölçeklenmiş halde teslim ediyoruz.
+                    </p>
+                </div>
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Butik ofis iletişim tonu için AI konsept"
+                        class="ai-visual h-36 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 70% 25%, rgba(255, 172, 225, 0.55) 0%, rgba(255, 172, 225, 0) 48%), radial-gradient(circle at 15% 50%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(155deg, #191927, #101018 62%, #2e243d);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">İletişim Tonu</p>
+                    <h3 class="text-2xl font-display text-white">Butik Yaklaşım</h3>
+                    <p class="text-sm text-white/70">
+                        Metinleri Türkçe ve İngilizce hazırlayıp aynı görsel dili kullanıyoruz.
+                        Geri bildirimlerinize göre yeni AI görselleri üreterek paketlerin güncel kalmasını sağlıyoruz.
                     </p>
                 </div>
             </div>
-            <div class="mt-16 grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
-                <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
-                    <img
-                        alt="Design team in conversation"
-                        class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                        src="https://images.unsplash.com/photo-1529429617124-aee575b5dbb3?auto=format&fit=crop&w=1100&q=80"
-                    />
-                    <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
-                    <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Studio Life</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Inside the Istanbul Atelier</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Collaborative spaces that bring craft, technology, and dialogue together.</p>
-                    </div>
-                </article>
-                <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
-                    <img
-                        alt="Modern cultural pavilion"
-                        class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                        src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1100&q=80"
-                    />
-                    <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
-                    <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Perspective</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Resilient Cultural Landscapes</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Design strategies that respond to climate while celebrating local narratives.</p>
-                    </div>
-                </article>
-                <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
-                    <img
-                        alt="High-rise skyline"
-                        class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                        src="https://images.unsplash.com/photo-1487956382158-bb926046304a?auto=format&fit=crop&w=1100&q=80"
-                    />
-                    <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
-                    <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Global Practice</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Elevating Urban Skylines</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Hybrid towers that balance hospitality, culture, and public experience.</p>
-                    </div>
-                </article>
-            </div>
         </section>
     </main>
+
+    <div
+        class="fixed inset-0 z-40 hidden opacity-0 bg-black/70 backdrop-blur-md transition-opacity"
+        id="search-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="search-title"
+    >
+        <div class="mx-auto mt-32 w-full max-w-2xl rounded-sm border border-white/15 bg-background-dark p-8 text-white shadow-2xl">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="search-title">Site İçi Arama</p>
+                    <h2 class="mt-3 text-3xl font-display text-white">Sunum İçeriklerinde Ara</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="search-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <form class="mt-8 space-y-4" role="search">
+                <label class="block text-sm uppercase tracking-[0.35em] text-white/60" for="search-input">Anahtar Kelime</label>
+                <input
+                    class="w-full border border-white/20 bg-black/40 p-4 text-base text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                    id="search-input"
+                    placeholder="Örn. lobi görseli, gece cephesi"
+                    type="search"
+                />
+                <button
+                    class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20"
+                    type="submit"
+                >
+                    Arama Yap
+                </button>
+            </form>
+            <p class="mt-6 text-sm text-white/60">
+                Yapay zekâ ile üretilen görsel arşivimizi, başlık ve tema bazlı filtrelerle düzenliyoruz. İlk sürümde sonuç listesi taslağı gösterilir.
+            </p>
+        </div>
+    </div>
 
     <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
         <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
@@ -281,6 +375,11 @@
         const slideLocation = document.getElementById('slide-location');
         const slideIndex = document.getElementById('slide-index');
         const slideTotal = document.getElementById('slide-total');
+        const searchToggle = document.getElementById('search-toggle');
+        const searchPanel = document.getElementById('search-panel');
+        const searchClose = document.getElementById('search-close');
+        const searchInput = document.getElementById('search-input');
+        const languageSelect = document.getElementById('language-select');
         const totalItems = items.length;
 
         let currentIndex = 0;
@@ -349,6 +448,58 @@
             showPrev();
             startAutoplay();
         });
+
+        const openSearchPanel = () => {
+            if (!searchPanel) return;
+            searchPanel.classList.remove('hidden');
+            searchPanel.classList.remove('opacity-0');
+            setTimeout(() => {
+                searchPanel.classList.add('opacity-100');
+            }, 10);
+            if (searchInput) {
+                setTimeout(() => searchInput.focus(), 120);
+            }
+            stopAutoplay();
+        };
+
+        const closeSearchPanel = () => {
+            if (!searchPanel) return;
+            searchPanel.classList.remove('opacity-100');
+            searchPanel.classList.add('opacity-0');
+            setTimeout(() => {
+                searchPanel.classList.add('hidden');
+            }, 180);
+            startAutoplay();
+        };
+
+        if (searchToggle) {
+            searchToggle.addEventListener('click', openSearchPanel);
+        }
+
+        if (searchClose) {
+            searchClose.addEventListener('click', closeSearchPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && searchPanel && !searchPanel.classList.contains('hidden')) {
+                closeSearchPanel();
+            }
+        });
+
+        if (searchPanel) {
+            searchPanel.addEventListener('click', (event) => {
+                if (event.target === searchPanel) {
+                    closeSearchPanel();
+                }
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
 
         slideTotal.textContent = padNumber(totalItems);
         goToSlide(0);

--- a/insights.html
+++ b/insights.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title>Insights — Alper Morkoç Architecture</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black/60 px-8 py-6 backdrop-blur-md md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white">Alper Morkoç</span> Architecture
+            </a>
+            <nav class="hidden items-center space-x-10 text-xs uppercase tracking-[0.45em] text-white/70 md:flex">
+                <a class="transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                <a class="transition-opacity hover:opacity-60" href="services.html">Services</a>
+                <a class="transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                <a class="transition-opacity hover:opacity-60" href="contact.html">Contact</a>
+            </nav>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" for="language-select">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="language-select"
+                >
+                    <option value="tr" selected>TR</option>
+                    <option value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="search-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">search</span>
+                    <span>Search</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="max-w-5xl space-y-12">
+            <p class="text-xs uppercase tracking-[0.55em] text-accent">Görüşler & Notlar</p>
+            <h1 class="text-4xl font-display text-white md:text-5xl">AMA Not Defteri</h1>
+            <p class="text-base text-white/70">
+                Küçük bir mimarlık ofisinin, henüz projeleri olmadan bile etkileyici sunumlar hazırlayabilmesi için öğrendiklerimizi düzenli olarak paylaşıyoruz.
+                Burada yer alan tüm makaleler, yapay zekâ ile görselleştirilmiş örnek senaryolar ve kısa uygulama rehberleri içerir.
+            </p>
+            <div class="space-y-8">
+                <article class="space-y-3 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Lobi sahnesi için AI oluşturulmuş renk denemesi"
+                        class="ai-visual h-32 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 22% 30%, rgba(255, 206, 165, 0.8) 0%, rgba(255, 206, 165, 0) 55%), radial-gradient(circle at 78% 65%, rgba(255, 126, 126, 0.45) 0%, rgba(255, 126, 126, 0) 50%), linear-gradient(150deg, #1e1f2d, #101019 58%, #2e2439);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">Saha Notu</p>
+                    <h2 class="text-2xl font-display text-white">AI Render ile İlk İzlenim</h2>
+                    <p class="text-sm text-white/70">
+                        İlk toplantıda paylaşılan lobi sahnesi, müşterinin mekân hissini anlamasını hızlandırıyor. Kullanılan prompt örneklerini ve ışık ayarlarını paylaşıyoruz.
+                    </p>
+                    <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" href="#">
+                        Devamını Oku
+                        <span class="material-icons ml-2 text-sm">east</span>
+                    </a>
+                </article>
+                <article class="space-y-3 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Metinsiz sahne anlatımı için AI kolaj"
+                        class="ai-visual h-32 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 70% 30%, rgba(160, 214, 255, 0.7) 0%, rgba(160, 214, 255, 0) 55%), radial-gradient(circle at 18% 70%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(160deg, #1a2334, #0f131d 60%, #2a3245);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">Rehber</p>
+                    <h2 class="text-2xl font-display text-white">Metinsiz Sahne Nasıl Anlatılır?</h2>
+                    <p class="text-sm text-white/70">
+                        Görsel olmayan bölümler için kullandığımız üç adımlı strateji: atmosfer tanımı, kullanıcı deneyimi kısa hikâyesi ve AI görsel alternatifi.
+                    </p>
+                    <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" href="#">
+                        Devamını Oku
+                        <span class="material-icons ml-2 text-sm">east</span>
+                    </a>
+                </article>
+                <article class="space-y-3 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Prompt seansları için AI ışık denemesi"
+                        class="ai-visual h-32 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 50%), radial-gradient(circle at 78% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #141522, #1c1f31 58%, #322544);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">Atölye Özeti</p>
+                    <h2 class="text-2xl font-display text-white">Takım İçi Prompt Seansları</h2>
+                    <p class="text-sm text-white/70">
+                        Haftalık oturumlarımızda kullandığımız sahne tariflerini, ışık önerilerini ve renk paleti kombinlerini örnek dosyalarla birlikte topladık.
+                    </p>
+                    <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" href="#">
+                        Devamını Oku
+                        <span class="material-icons ml-2 text-sm">east</span>
+                    </a>
+                </article>
+            </div>
+        </div>
+    </main>
+
+    <div
+        class="fixed inset-0 z-40 hidden opacity-0 bg-black/70 backdrop-blur-md transition-opacity"
+        id="search-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="search-title"
+    >
+        <div class="mx-auto mt-32 w-full max-w-2xl rounded-sm border border-white/15 bg-background-dark p-8 text-white shadow-2xl">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="search-title">Site İçi Arama</p>
+                    <h2 class="mt-3 text-3xl font-display text-white">Sunum İçeriklerinde Ara</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="search-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <form class="mt-8 space-y-4" role="search">
+                <label class="block text-sm uppercase tracking-[0.35em] text-white/60" for="search-input">Anahtar Kelime</label>
+                <input
+                    class="w-full border border-white/20 bg-black/40 p-4 text-base text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                    id="search-input"
+                    placeholder="Örn. prompt, render ayarı"
+                    type="search"
+                />
+                <button
+                    class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20"
+                    type="submit"
+                >
+                    Arama Yap
+                </button>
+            </form>
+            <p class="mt-6 text-sm text-white/60">
+                Yapay zekâ ile üretilen görsel arşivimizi, başlık ve tema bazlı filtrelerle düzenliyoruz. İlk sürümde sonuç listesi taslağı gösterilir.
+            </p>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alper Morkoç Architecture</h3>
+                <p class="mt-3 text-sm text-gray-400">
+                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Join
+                    </button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p>© 2024 Alper Morkoç Architecture. All Rights Reserved.</p>
+        </div>
+    </footer>
+
+    <script>
+        const searchToggle = document.getElementById('search-toggle');
+        const searchPanel = document.getElementById('search-panel');
+        const searchClose = document.getElementById('search-close');
+        const searchInput = document.getElementById('search-input');
+        const languageSelect = document.getElementById('language-select');
+
+        const openSearchPanel = () => {
+            if (!searchPanel) return;
+            searchPanel.classList.remove('hidden');
+            searchPanel.classList.remove('opacity-0');
+            setTimeout(() => searchPanel.classList.add('opacity-100'), 10);
+            if (searchInput) {
+                setTimeout(() => searchInput.focus(), 120);
+            }
+        };
+
+        const closeSearchPanel = () => {
+            if (!searchPanel) return;
+            searchPanel.classList.remove('opacity-100');
+            searchPanel.classList.add('opacity-0');
+            setTimeout(() => searchPanel.classList.add('hidden'), 180);
+        };
+
+        if (searchToggle) {
+            searchToggle.addEventListener('click', openSearchPanel);
+        }
+
+        if (searchClose) {
+            searchClose.addEventListener('click', closeSearchPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && searchPanel && !searchPanel.classList.contains('hidden')) {
+                closeSearchPanel();
+            }
+        });
+
+        if (searchPanel) {
+            searchPanel.addEventListener('click', (event) => {
+                if (event.target === searchPanel) {
+                    closeSearchPanel();
+                }
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
+    </script>
+</body>
+</html>

--- a/services.html
+++ b/services.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title>Services — Alper Morkoç Architecture</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black/60 px-8 py-6 backdrop-blur-md md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white">Alper Morkoç</span> Architecture
+            </a>
+            <nav class="hidden items-center space-x-10 text-xs uppercase tracking-[0.45em] text-white/70 md:flex">
+                <a class="transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                <a class="transition-opacity hover:opacity-60" href="services.html">Services</a>
+                <a class="transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                <a class="transition-opacity hover:opacity-60" href="contact.html">Contact</a>
+            </nav>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" for="language-select">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="language-select"
+                >
+                    <option value="tr" selected>TR</option>
+                    <option value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="search-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">search</span>
+                    <span>Search</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="max-w-5xl space-y-12">
+            <p class="text-xs uppercase tracking-[0.55em] text-accent">Hizmet Paketleri</p>
+            <h1 class="text-4xl font-display text-white md:text-5xl">Sunum Odaklı Mimarlık Servisleri</h1>
+            <p class="text-base text-white/70">
+                Henüz fiziki projeleri olmayan küçük ölçekli ofisler için konseptleri sahneleyen tanıtım paketleri hazırlıyoruz.
+                AI ile oluşturduğumuz görseller ve kısa metin blokları, ilk görüşmede güven veren bir vitrin sunmanıza yardımcı oluyor.
+            </p>
+            <div class="grid gap-10 md:grid-cols-2">
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Vizyon kitabı için hazırlanan AI görsel"
+                        class="ai-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 22% 25%, rgba(255, 206, 165, 0.8) 0%, rgba(255, 206, 165, 0) 55%), radial-gradient(circle at 78% 70%, rgba(255, 132, 132, 0.48) 0%, rgba(255, 132, 132, 0) 50%), linear-gradient(150deg, #1f1f2f, #101019 58%, #2f253a);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">01</p>
+                    <h2 class="text-2xl font-display text-white">Vizyon Kitabı</h2>
+                    <p class="text-sm text-white/70">
+                        Üç bölümlü dijital kitap, lobi, çalışma alanı ve cephe sahnelerini aynı dilde anlatır.
+                        AI ile ürettiğimiz görseller, başlıklarla birlikte kullanılmaya hazır halde teslim edilir.
+                    </p>
+                </div>
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Sunum sahnesi paketine ait AI storyboard"
+                        class="ai-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 65% 35%, rgba(162, 216, 255, 0.7) 0%, rgba(162, 216, 255, 0) 55%), radial-gradient(circle at 20% 75%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(160deg, #1b2436, #0f141f 60%, #293347);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">02</p>
+                    <h2 class="text-2xl font-display text-white">Sunum Sahnesi</h2>
+                    <p class="text-sm text-white/70">
+                        Pitch toplantıları için hazırlanan bu paket, hareketli slayt akışı ve kısa tanıtım filmiyle desteklenir.
+                        Boş ekranları, ofis kimliğinize uygun AI kolajlarla tamamlıyoruz.
+                    </p>
+                </div>
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Dijital basın dosyasına ait AI kolaj"
+                        class="ai-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 50%), radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #131422, #1d1f31 58%, #332645);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">03</p>
+                    <h2 class="text-2xl font-display text-white">Dijital Basın Dosyası</h2>
+                    <p class="text-sm text-white/70">
+                        Basın bültenleri ve sosyal medya lansmanları için hızlıca özelleştirebileceğiniz şablonlar içerir.
+                        Her görsel, stüdyonuzun tonunu anlatan kısa açıklamalarla birlikte gelir.
+                    </p>
+                </div>
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="AI workshop oturumu için hazırlanan görsel"
+                        class="ai-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 70% 25%, rgba(255, 208, 158, 0.7) 0%, rgba(255, 208, 158, 0) 52%), radial-gradient(circle at 20% 70%, rgba(161, 218, 255, 0.6) 0%, rgba(161, 218, 255, 0) 45%), linear-gradient(155deg, #181a27, #0f1119 58%, #2b253a);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">04</p>
+                    <h2 class="text-2xl font-display text-white">Danışmanlık & Eğitim</h2>
+                    <p class="text-sm text-white/70">
+                        Ekibinizin kendi AI görsellerini üretebilmesi için kısa atölyeler düzenliyoruz.
+                        Prompt kütüphaneleri, renk paleti önerileri ve sunum şablonlarıyla süreci sürdürülebilir kılıyoruz.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <div
+        class="fixed inset-0 z-40 hidden opacity-0 bg-black/70 backdrop-blur-md transition-opacity"
+        id="search-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="search-title"
+    >
+        <div class="mx-auto mt-32 w-full max-w-2xl rounded-sm border border-white/15 bg-background-dark p-8 text-white shadow-2xl">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="search-title">Site İçi Arama</p>
+                    <h2 class="mt-3 text-3xl font-display text-white">Sunum İçeriklerinde Ara</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="search-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <form class="mt-8 space-y-4" role="search">
+                <label class="block text-sm uppercase tracking-[0.35em] text-white/60" for="search-input">Anahtar Kelime</label>
+                <input
+                    class="w-full border border-white/20 bg-black/40 p-4 text-base text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                    id="search-input"
+                    placeholder="Örn. sunum paketi, render"
+                    type="search"
+                />
+                <button
+                    class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20"
+                    type="submit"
+                >
+                    Arama Yap
+                </button>
+            </form>
+            <p class="mt-6 text-sm text-white/60">
+                Yapay zekâ ile üretilen görsel arşivimizi, başlık ve tema bazlı filtrelerle düzenliyoruz. İlk sürümde sonuç listesi taslağı gösterilir.
+            </p>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alper Morkoç Architecture</h3>
+                <p class="mt-3 text-sm text-gray-400">
+                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Join
+                    </button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p>© 2024 Alper Morkoç Architecture. All Rights Reserved.</p>
+        </div>
+    </footer>
+
+    <script>
+        const searchToggle = document.getElementById('search-toggle');
+        const searchPanel = document.getElementById('search-panel');
+        const searchClose = document.getElementById('search-close');
+        const searchInput = document.getElementById('search-input');
+        const languageSelect = document.getElementById('language-select');
+
+        const openSearchPanel = () => {
+            if (!searchPanel) return;
+            searchPanel.classList.remove('hidden');
+            searchPanel.classList.remove('opacity-0');
+            setTimeout(() => searchPanel.classList.add('opacity-100'), 10);
+            if (searchInput) {
+                setTimeout(() => searchInput.focus(), 120);
+            }
+        };
+
+        const closeSearchPanel = () => {
+            if (!searchPanel) return;
+            searchPanel.classList.remove('opacity-100');
+            searchPanel.classList.add('opacity-0');
+            setTimeout(() => searchPanel.classList.add('hidden'), 180);
+        };
+
+        if (searchToggle) {
+            searchToggle.addEventListener('click', openSearchPanel);
+        }
+
+        if (searchClose) {
+            searchClose.addEventListener('click', closeSearchPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && searchPanel && !searchPanel.classList.contains('hidden')) {
+                closeSearchPanel();
+            }
+        });
+
+        if (searchPanel) {
+            searchPanel.addEventListener('click', (event) => {
+                if (event.target === searchPanel) {
+                    closeSearchPanel();
+                }
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
+    </script>
+</body>
+</html>

--- a/studio.html
+++ b/studio.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title>Studio — Alper Morkoç Architecture</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black/60 px-8 py-6 backdrop-blur-md md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white">Alper Morkoç</span> Architecture
+            </a>
+            <nav class="hidden items-center space-x-10 text-xs uppercase tracking-[0.45em] text-white/70 md:flex">
+                <a class="transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                <a class="transition-opacity hover:opacity-60" href="services.html">Services</a>
+                <a class="transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                <a class="transition-opacity hover:opacity-60" href="contact.html">Contact</a>
+            </nav>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" for="language-select">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="language-select"
+                >
+                    <option value="tr" selected>TR</option>
+                    <option value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="search-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">search</span>
+                    <span>Search</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="max-w-4xl space-y-10">
+            <p class="text-xs uppercase tracking-[0.55em] text-accent">Stüdyo Hikâyesi</p>
+            <h1 class="text-4xl font-display text-white md:text-5xl">Butik Ofisin Arka Planı</h1>
+            <p class="text-base text-white/70">
+                AMA, henüz portföyünü paylaşmayan küçük bir mimarlık ofisi.
+                Tanıtım kitapçıklarında boş kalan bölümleri, ekip içinde hazırladığımız AI görselleriyle dolduruyor ve sunumların sıcak bir dilde ilerlemesini sağlıyoruz.
+            </p>
+            <div class="grid gap-6 md:grid-cols-3">
+                <figure class="overflow-hidden rounded-sm border border-white/10 bg-black/40">
+                    <div
+                        aria-label="Çalışma masalarının yer aldığı AI stüdyo görseli"
+                        class="ai-visual h-48"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 25% 25%, rgba(255, 208, 158, 0.8) 0%, rgba(255, 208, 158, 0) 55%), radial-gradient(circle at 75% 70%, rgba(255, 126, 126, 0.5) 0%, rgba(255, 126, 126, 0) 45%), linear-gradient(145deg, #222232, #101019 60%, #30253e);"
+                    ></div>
+                    <figcaption class="p-4 text-xs uppercase tracking-[0.35em] text-white/60">Planlama Odası</figcaption>
+                </figure>
+                <figure class="overflow-hidden rounded-sm border border-white/10 bg-black/40">
+                    <div
+                        aria-label="Giriş holünü gösteren AI render"
+                        class="ai-visual h-48"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 70% 30%, rgba(160, 214, 255, 0.75) 0%, rgba(160, 214, 255, 0) 55%), radial-gradient(circle at 20% 75%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(150deg, #1b2435, #0f141f 58%, #2a3247);"
+                    ></div>
+                    <figcaption class="p-4 text-xs uppercase tracking-[0.35em] text-white/60">Lobi Vinyeti</figcaption>
+                </figure>
+                <figure class="overflow-hidden rounded-sm border border-white/10 bg-black/40">
+                    <div
+                        aria-label="Gece cephe aydınlatmasını betimleyen AI görsel"
+                        class="ai-visual h-48"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 20% 70%, rgba(255, 172, 225, 0.55) 0%, rgba(255, 172, 225, 0) 52%), radial-gradient(circle at 80% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #121422, #1c1f31 55%, #302445);"
+                    ></div>
+                    <figcaption class="p-4 text-xs uppercase tracking-[0.35em] text-white/60">Cephe Senaryosu</figcaption>
+                </figure>
+            </div>
+            <div class="space-y-6">
+                <h2 class="text-2xl font-display text-white">Yaklaşımımız</h2>
+                <p class="text-sm text-white/70">
+                    Toplantı öncesi paylaşılan kitapçıklarda, ölçeksiz eskizleri ve AI ile üretilen sahne önerilerini yan yana kurguluyoruz.
+                    Her görsel, mekânın hissini anlatan kısa notlarla destekleniyor.
+                </p>
+                <p class="text-sm text-white/70">
+                    Bu sayede henüz bir uygulama dosyası oluşmadan, yatırımcılara ofisin karakterini net şekilde gösteren tanıtım klasörleri hazırlıyoruz.
+                </p>
+            </div>
+        </div>
+    </main>
+
+    <div
+        class="fixed inset-0 z-40 hidden opacity-0 bg-black/70 backdrop-blur-md transition-opacity"
+        id="search-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="search-title"
+    >
+        <div class="mx-auto mt-32 w-full max-w-2xl rounded-sm border border-white/15 bg-background-dark p-8 text-white shadow-2xl">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="search-title">Site İçi Arama</p>
+                    <h2 class="mt-3 text-3xl font-display text-white">Sunum İçeriklerinde Ara</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="search-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <form class="mt-8 space-y-4" role="search">
+                <label class="block text-sm uppercase tracking-[0.35em] text-white/60" for="search-input">Anahtar Kelime</label>
+                <input
+                    class="w-full border border-white/20 bg-black/40 p-4 text-base text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                    id="search-input"
+                    placeholder="Örn. lobi görseli, gece cephesi"
+                    type="search"
+                />
+                <button
+                    class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20"
+                    type="submit"
+                >
+                    Arama Yap
+                </button>
+            </form>
+            <p class="mt-6 text-sm text-white/60">
+                Yapay zekâ ile üretilen görsel arşivimizi, başlık ve tema bazlı filtrelerle düzenliyoruz. İlk sürümde sonuç listesi taslağı gösterilir.
+            </p>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alper Morkoç Architecture</h3>
+                <p class="mt-3 text-sm text-gray-400">
+                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Join
+                    </button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p>© 2024 Alper Morkoç Architecture. All Rights Reserved.</p>
+        </div>
+    </footer>
+
+    <script>
+        const searchToggle = document.getElementById('search-toggle');
+        const searchPanel = document.getElementById('search-panel');
+        const searchClose = document.getElementById('search-close');
+        const searchInput = document.getElementById('search-input');
+        const languageSelect = document.getElementById('language-select');
+
+        const openSearchPanel = () => {
+            if (!searchPanel) return;
+            searchPanel.classList.remove('hidden');
+            searchPanel.classList.remove('opacity-0');
+            setTimeout(() => searchPanel.classList.add('opacity-100'), 10);
+            if (searchInput) {
+                setTimeout(() => searchInput.focus(), 120);
+            }
+        };
+
+        const closeSearchPanel = () => {
+            if (!searchPanel) return;
+            searchPanel.classList.remove('opacity-100');
+            searchPanel.classList.add('opacity-0');
+            setTimeout(() => searchPanel.classList.add('hidden'), 180);
+        };
+
+        if (searchToggle) {
+            searchToggle.addEventListener('click', openSearchPanel);
+        }
+
+        if (searchClose) {
+            searchClose.addEventListener('click', closeSearchPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && searchPanel && !searchPanel.classList.contains('hidden')) {
+                closeSearchPanel();
+            }
+        });
+
+        if (searchPanel) {
+            searchPanel.addEventListener('click', (event) => {
+                if (event.target === searchPanel) {
+                    closeSearchPanel();
+                }
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace homepage placeholder images with custom AI concept panels and add a reusable gradient style
- extend the AI concept imagery and simplified copy across the Studio, Services, Insights, and Contact pages to keep empty sections visually engaging

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d53a8c5f108325b25812249027112e