### PR TITLE
Convert site navigation to slide-out menu and rebrand

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title>Contact — Alpimimarlık</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .concept-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .concept-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black/60 px-8 py-6 backdrop-blur-md md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" for="language-select">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="language-select"
+                >
+                    <option value="tr" selected>TR</option>
+                    <option value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span>Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="grid gap-16 md:grid-cols-[2fr,1fr]">
+            <div class="space-y-10">
+                <div
+                    aria-label="Stüdyo girişini anlatan konsept görsel"
+                    class="concept-visual h-48 w-full"
+                    role="img"
+                    style="background-image: radial-gradient(circle at 22% 28%, rgba(255, 208, 158, 0.8) 0%, rgba(255, 208, 158, 0) 55%), radial-gradient(circle at 78% 68%, rgba(161, 218, 255, 0.6) 0%, rgba(161, 218, 255, 0) 48%), linear-gradient(150deg, #1a1c28, #0f1119 60%, #2d253a);"
+                ></div>
+                <p class="text-xs uppercase tracking-[0.55em] text-accent">İletişim</p>
+                <h1 class="text-4xl font-display text-white md:text-5xl">Bize Ulaşın</h1>
+                <p class="text-base text-white/70">
+                    Kampanya odaklı mimarlık sunumlarımız hakkında konuşmak veya sunum arşivimizi incelemek isterseniz, aşağıdaki formu doldurun.
+                    İlk kez sunum hazırlayan ekipler için hızlı başlangıç oturumu planlıyoruz.
+                </p>
+                <form class="space-y-6">
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label class="block text-xs uppercase tracking-[0.4em] text-white/60" for="contact-name">Ad Soyad</label>
+                            <input class="mt-2 w-full border border-white/15 bg-black/40 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none" id="contact-name" placeholder="Adınız Soyadınız" type="text"/>
+                        </div>
+                        <div>
+                            <label class="block text-xs uppercase tracking-[0.4em] text-white/60" for="contact-email">E-posta</label>
+                            <input class="mt-2 w-full border border-white/15 bg-black/40 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none" id="contact-email" placeholder="ornek@studio.com" type="email"/>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-xs uppercase tracking-[0.4em] text-white/60" for="contact-topic">Sunum İlgisi</label>
+                        <select class="mt-2 w-full border border-white/15 bg-black/40 p-3 text-sm text-white focus:border-white focus:outline-none" id="contact-topic">
+                            <option>Konsept kitap hazırlığı</option>
+                            <option>Render ve görselleştirme oturumu</option>
+                            <option>Dijital lansman seti</option>
+                            <option>Diğer</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-xs uppercase tracking-[0.4em] text-white/60" for="contact-message">Mesajınız</label>
+                        <textarea class="mt-2 h-32 w-full border border-white/15 bg-black/40 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none" id="contact-message" placeholder="Ekibinizin ihtiyacını kısaca anlatın..."></textarea>
+                    </div>
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Gönder
+                    </button>
+                </form>
+            </div>
+            <aside class="space-y-8 border border-white/10 bg-black/30 p-6">
+                <div
+                    aria-label="Galata stüdyo atmosferini anlatan konsept görsel"
+                    class="concept-visual h-32 w-full"
+                    role="img"
+                    style="background-image: radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 48%), radial-gradient(circle at 78% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #131522, #1d1f31 58%, #302544);"
+                ></div>
+                <div class="space-y-2">
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">Stüdyo</p>
+                    <p class="text-sm text-white/70">Istanbul, Galata</p>
+                    <p class="text-sm text-white/60">Hafta içi 10:00 - 18:00 arası randevu ile görüşme sağlanır.</p>
+                </div>
+                <div class="space-y-2">
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">Telefon</p>
+                    <a class="text-sm text-white/70 transition hover:text-white" href="tel:+902122223344">+90 212 222 33 44</a>
+                </div>
+                <div class="space-y-2">
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">E-posta</p>
+                    <a class="text-sm text-white/70 transition hover:text-white" href="mailto:iletisim@alpimimarlik.com">iletisim@alpimimarlik.com</a>
+                </div>
+                <div class="space-y-2">
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">Sunum Arşivi</p>
+                    <p class="text-sm text-white/60">
+                        Sunum öncesi paylaşılacak örnek görseller için özel bir galeri bağlantısı oluşturuyoruz. Talep formunda belirtin.
+                    </p>
+                </div>
+            </aside>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40">İletişim</p>
+                <p>Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400">
+                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Join
+                    </button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p>© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+        const languageSelect = document.getElementById('language-select');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html class="dark" lang="en">
+<html class="dark" lang="tr">
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <title>AMA - Alper Morkoç Architecture</title>
+    <title>Alpimimarlık — Ana Sayfa</title>
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
@@ -50,52 +50,71 @@
         .reveal {
             animation: reveal 0.6s ease forwards;
         }
+
+        .concept-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .concept-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
     </style>
 </head>
 <body class="bg-background-dark text-primary font-body antialiased">
     <main>
-        <section class="relative h-screen min-h-[650px] overflow-hidden text-white">
+        <section class="relative min-h-[780px] md:min-h-[900px] lg:min-h-[1000px] overflow-hidden text-white">
             <div class="absolute inset-0">
                 <div class="flex h-full w-full transition-transform duration-700 ease-in-out" id="carousel">
                     <div
                         class="carousel-item relative h-full w-full"
-                        data-category="Residential"
-                        data-description="Revealing the first glimpses of life in a serene coastal retreat where refined lines meet the Aegean horizon."
-                        data-location="Bodrum, TR"
-                        data-title="Nef Reserve Gölköy"
+                        data-category="Kampanya Vitrini"
+                        data-description="Gün ışığıyla nefes alan çalışma adaları, yeni ofisimizin sakin ama üretken temposunu sahne ışığı altına taşıyor."
+                        data-location="Merkez Stüdyo"
+                        data-title="Gün Doğumu Stüdyo Kurgusu"
                     >
                         <img
-                            alt="Nef Reserve Gölköy"
+                            alt="Cam duvarlarla çevrili aydınlık çalışma alanı"
                             class="h-full w-full object-cover"
-                            src="https://lh3.googleusercontent.com/aida-public/AB6AXuBY3ViKq1aw3yXDhhfDzgn7d0Vnt9jkYwQLGkJo0WUnOSAcz06Acijs0rfUd0xb9zxwwedHo2UBB6vTEREgApkNX5S4pv1vRV9RH5B9nCgadZSPz8edx5Oegr7Vkl61cWtBT8vpoeYYONTO_1dQasguKJknaYBs5x-ksJA5c-Xwg-FAO92cpnoXersUR8s4cA3gg84RtdesgofL6GVefDsHtJABqFzz-Eiljg6sCLAXqvHOLTd-bZt5Avma1ITGxYiogtxhLn5cU3s"
+                            src="https://images.unsplash.com/photo-1497366216548-37526070297c?auto=format&fit=crop&w=1600&q=80"
                         />
                         <div class="absolute inset-0 bg-gradient-to-r from-black/80 via-black/30 to-black/40"></div>
                     </div>
                     <div
                         class="carousel-item relative h-full w-full"
-                        data-category="Cultural"
-                        data-description="A sculpted public space in Riyadh that folds desert light into a contemporary urban experience."
-                        data-location="Riyadh, SA"
-                        data-title="Al Sahra Pavilion"
+                        data-category="Mekân Lansmanı"
+                        data-description="Doğal taş ve yumuşak aydınlatma birlikteliği, giriş holünü markamızın sıcak tonlarıyla buluşturan davetkâr bir sahneye dönüştürüyor."
+                        data-location="Giriş Holü"
+                        data-title="Yumuşak Işıkta Karşılama"
                     >
                         <img
-                            alt="Architectural detail of a modern building"
+                            alt="Ahşap detaylara sahip sıcak karşılaşma alanı"
                             class="h-full w-full object-cover"
-                            src="https://lh3.googleusercontent.com/aida-public/AB6AXuDywh5KHJIrXp4s52K1q899PeRE9lFxVweHMW2m5xVN5GAmy9rXujubUdVBDEb-52DZCJp8ESyuMVD_iEpICFtvVL6QsGb93VmuZxZS2PJB6fJAIbiNy8gFLVVeLF4ljljtdkYfvQ4Zth5632bC7EwePczCSU-byb1tPIHSyUcXztEFgLEIO51I97KC8pNhm7AiIDRl0eeST75VN8H9S7ncLlFfgKAAeySs12gW0IO-bRgtDVQ4sq1_n5jqPeqOZDy0fEuyZiJHm0"
+                            src="https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1600&q=80"
                         />
                         <div class="absolute inset-0 bg-gradient-to-r from-black/80 via-black/40 to-black/20"></div>
                     </div>
                     <div
                         class="carousel-item relative h-full w-full"
-                        data-category="Hospitality"
-                        data-description="An immersive interior landscape that blurs the threshold between nature, art, and crafted comfort."
-                        data-location="Istanbul, TR"
-                        data-title="Aether Residence"
+                        data-category="Gece Senaryosu"
+                        data-description="Kentin ritmine eşlik eden cephe ışıkları, ofisimizin akşam saatlerindeki rafine duruşunu panoramaya taşıyor."
+                        data-location="Kent Silueti"
+                        data-title="Akşam Cephesi"
                     >
                         <img
-                            alt="Interior of a modern house"
+                            alt="Gece ışıklarıyla parlayan ofis cephesi"
                             class="h-full w-full object-cover"
-                            src="https://lh3.googleusercontent.com/aida-public/AB6AXuAGbCFIA5CK9Pt4bi0fEdIphWGRzysF0RACqcAQrhCRIPHNhljJIo6DXOsFA5HPMoO8zXERyza-Pl9_e2OnZ-xhgdR2DLkBdVZYKQhOU427ZgDH9NZowetlX5r8f0oCfikqMJkrSuabc9Pi1C7s9zIfz3eUbptgsAll8sluvlI2-86xYefKmDEughe06TuGjVz0RSjVQXHL9l_ze9uidcyYGPuDr_t-CPGqqwi2ZkM7eIn8BIcOvFtdYcURahWa7XoWGf4HO3kRaHY"
+                            src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80"
                         />
                         <div class="absolute inset-0 bg-gradient-to-r from-black/85 via-black/40 to-black/10"></div>
                     </div>
@@ -104,31 +123,39 @@
             <div class="pointer-events-none absolute inset-0 bg-gradient-to-b from-black via-black/10 to-background-dark"></div>
 
             <header class="absolute top-0 left-0 right-0 z-30 px-8 py-10 md:px-16">
-                <div class="flex items-center justify-between">
-                    <div class="text-sm font-display uppercase tracking-[0.6em] text-white/80">
-                        <span class="font-bold text-white">Alper Morkoç</span> Architecture
+                <div class="flex items-center justify-between gap-8">
+                    <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                        <span class="font-bold text-white">Alpimimarlık</span>
+                    </a>
+                    <div class="flex items-center gap-4">
+                        <label class="sr-only" for="language-select">Dil Seçimi</label>
+                        <select
+                            class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                            id="language-select"
+                        >
+                            <option value="tr" selected>TR</option>
+                            <option value="en">EN</option>
+                        </select>
+                        <button
+                            class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                            id="menu-toggle"
+                            type="button"
+                        >
+                            <span class="material-icons text-base">menu</span>
+                            <span>Menü</span>
+                        </button>
                     </div>
-                    <nav class="hidden items-center space-x-10 text-xs uppercase tracking-[0.45em] text-white/70 md:flex">
-                        <a class="transition-opacity hover:opacity-60" href="#">Studio</a>
-                        <a class="transition-opacity hover:opacity-60" href="#">Projects</a>
-                        <a class="transition-opacity hover:opacity-60" href="#">Insights</a>
-                        <a class="transition-opacity hover:opacity-60" href="#">Contact</a>
-                    </nav>
-                    <button class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60">
-                        <span class="material-icons text-base">search</span>
-                        <span>Search</span>
-                    </button>
                 </div>
             </header>
 
             <div class="relative z-20 flex h-full flex-col justify-end px-8 pb-24 md:px-20">
                 <div class="pointer-events-auto max-w-3xl space-y-6">
-                    <p class="text-xs uppercase tracking-[0.55em] text-white/60" id="slide-category">Residential</p>
+                    <p class="text-xs uppercase tracking-[0.55em] text-white/60" id="slide-category">Kampanya Vitrini</p>
                     <h1 class="text-4xl font-display font-light leading-[1.1] text-white transition-all duration-500 md:text-6xl" id="slide-title">
-                        Nef Reserve Gölköy
+                        Gün Doğumu Stüdyo Kurgusu
                     </h1>
                     <p class="text-sm text-white/70 md:text-base" id="slide-description">
-                        Revealing the first glimpses of life in a serene coastal retreat where refined lines meet the Aegean horizon.
+                        Gün ışığıyla nefes alan çalışma adaları, yeni ofisimizin sakin ama üretken temposunu sahne ışığı altına taşıyor.
                     </p>
                 </div>
                 <div class="pointer-events-auto mt-12 flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
@@ -137,7 +164,7 @@
                         <span class="font-display text-sm text-white" id="slide-index">01</span>
                         <span class="text-white/40">/</span>
                         <span class="font-display text-sm text-white/70" id="slide-total">03</span>
-                        <span class="text-white/50" id="slide-location">Bodrum, TR</span>
+                        <span class="text-white/50" id="slide-location">Merkez Stüdyo</span>
                     </div>
                     <div class="flex items-center gap-6">
                         <div class="relative h-0.5 w-32 overflow-hidden bg-white/25">
@@ -172,63 +199,60 @@
         <section class="bg-background-dark px-8 py-20 text-primary md:px-20">
             <div class="flex flex-col gap-12 md:flex-row md:items-end md:justify-between">
                 <div>
-                    <p class="text-xs uppercase tracking-[0.55em] text-accent">Featured Works</p>
-                    <h2 class="mt-4 max-w-2xl text-3xl font-display text-white md:text-5xl">Stories from Alper Morkoç Architecture</h2>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent">Stüdyo Vizyonu</p>
+                    <h2 class="mt-4 max-w-2xl text-3xl font-display text-white md:text-5xl">Alpimimarlık'ın Sunum Yaklaşımı</h2>
                 </div>
-                <div class="max-w-xl text-sm text-gray-400">
+                <div class="max-w-2xl space-y-5 text-sm text-gray-400">
                     <p>
-                        A curated selection of places, people, and crafted experiences that define the studio's multidimensional practice across the globe.
+                        Projelerimizi yalın anlatımlı sunumlar ve detaylı maket çalışmaları eşliğinde paylaşıyoruz. Hazırladığımız görsel sunumlar, ofisimizin ölçekli düşünme becerisini ve samimi iletişim dilini kısa tanıtım metinleriyle birlikte ortaya koymayı hedefliyor.
+                    </p>
+                    <p>
+                        Her sunum klasöründe, giriş sahnesinden gece cephe kurgusuna kadar uzanan atmosfer anlatıları yer alıyor. Hazırlık sürecinde paylaştığımız eskizler ve maket fotoğrafları, anlatının tonunu koruyarak ekiplerin tanıtım adımlarını hızlandırıyor.
                     </p>
                 </div>
-            </div>
-            <div class="mt-16 grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
-                <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
-                    <img
-                        alt="Design team in conversation"
-                        class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                        src="https://images.unsplash.com/photo-1529429617124-aee575b5dbb3?auto=format&fit=crop&w=1100&q=80"
-                    />
-                    <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
-                    <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Studio Life</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Inside the Istanbul Atelier</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Collaborative spaces that bring craft, technology, and dialogue together.</p>
-                    </div>
-                </article>
-                <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
-                    <img
-                        alt="Modern cultural pavilion"
-                        class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                        src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1100&q=80"
-                    />
-                    <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
-                    <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Perspective</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Resilient Cultural Landscapes</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Design strategies that respond to climate while celebrating local narratives.</p>
-                    </div>
-                </article>
-                <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
-                    <img
-                        alt="High-rise skyline"
-                        class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                        src="https://images.unsplash.com/photo-1487956382158-bb926046304a?auto=format&fit=crop&w=1100&q=80"
-                    />
-                    <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
-                    <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Global Practice</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Elevating Urban Skylines</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Hybrid towers that balance hospitality, culture, and public experience.</p>
-                    </div>
-                </article>
             </div>
         </section>
     </main>
 
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40">İletişim</p>
+                <p>Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
     <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
         <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
             <div>
-                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alper Morkoç Architecture</h3>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alpimimarlık</h3>
                 <p class="mt-3 text-sm text-gray-400">
                     Pioneering architectural narratives shaped by context, craft, and human experience.
                 </p>
@@ -265,7 +289,7 @@
             </div>
         </div>
         <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
-            <p>© 2024 Alper Morkoç Architecture. All Rights Reserved.</p>
+            <p>© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
         </div>
     </footer>
 
@@ -281,6 +305,10 @@
         const slideLocation = document.getElementById('slide-location');
         const slideIndex = document.getElementById('slide-index');
         const slideTotal = document.getElementById('slide-total');
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+        const languageSelect = document.getElementById('language-select');
         const totalItems = items.length;
 
         let currentIndex = 0;
@@ -349,6 +377,59 @@
             showPrev();
             startAutoplay();
         });
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => {
+                menuPanel.classList.add('opacity-100');
+            });
+            stopAutoplay();
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => {
+                menuPanel.classList.add('hidden');
+            }, 180);
+            startAutoplay();
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
 
         slideTotal.textContent = padNumber(totalItems);
         goToSlide(0);

--- a/insight-konsept-oturumlari.html
+++ b/insight-konsept-oturumlari.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title>Takım İçi Konsept Oturumları — Alpimimarlık Notları</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black/60 px-8 py-6 backdrop-blur-md md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" for="language-select">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="language-select"
+                >
+                    <option value="tr" selected>TR</option>
+                    <option value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span>Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="mx-auto max-w-4xl space-y-12">
+            <div class="space-y-6">
+                <p class="text-xs uppercase tracking-[0.55em] text-accent">Atölye Özeti</p>
+                <h1 class="text-4xl font-display text-white md:text-5xl">Takım İçi Konsept Oturumları</h1>
+                <p class="text-sm uppercase tracking-[0.35em] text-white/50">Yayın Tarihi — 26 Şubat 2024</p>
+                <div
+                    aria-label="Takım içi sunum oturumu için ışık denemesi"
+                    class="ai-visual h-60 w-full"
+                    role="img"
+                    style="background-image: radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 50%), radial-gradient(circle at 78% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #141522, #1c1f31 58%, #322544);"
+                ></div>
+                <p class="text-lg text-white/80">
+                    Haftalık olarak yaptığımız konsept oturumları, sunum dosyalarımızın tutarlı ve hızlı bir şekilde gelişmesini sağlıyor.
+                    Bu yazı, oturumların nasıl planlandığını, hangi çıktıları beklediğimizi ve ekip içinde görev paylaşımını nasıl yaptığımızı açıklıyor.
+                </p>
+            </div>
+
+            <article class="prose prose-invert max-w-none">
+                <h2>Toplantı düzeni</h2>
+                <p>
+                    Her oturum, 45 dakikalık zaman bloklarından oluşuyor. İlk bölümde bir kişi güncel sunum taslağını paylaşıyor.
+                    Diğer ekip üyeleri sorularını not alarak sadece dinliyor.
+                    Sunum tamamlandıktan sonra soruları sırayla yanıtlıyor ve gerekli revizyonları birlikte işaretliyoruz.
+                </p>
+                <p>
+                    Oturumda alınan notlar, toplantı sonrası 24 saat içinde paylaşılan kısa bir özetle dokümante ediliyor.
+                    Böylece herkes yapılacak işleri ve teslim tarihlerini net olarak görüyor.
+                </p>
+
+                <h2>Görsel kontrol listesi</h2>
+                <p>
+                    Her oturumun ikinci bölümünde, görsellerin tutarlılığını kontrol ediyoruz.
+                    Renk paleti, ışık yönleri ve malzeme anlatımı üç başlık altında değerlendiriliyor.
+                    Eksik bulunan kısımlar için sorumlu kişiyi belirleyip kısa teslim tarihleri veriyoruz.
+                </p>
+                <p>
+                    Bu yöntem, sunum dosyalarının farklı kişiler tarafından hazırlanmış olsa bile aynı dili konuşmasını sağlıyor.
+                </p>
+
+                <h2>Arşivleme ve paylaşım</h2>
+                <p>
+                    Oturum sonunda kullanılan tüm görsel ve dosyaları ortak sunucuda klasörleyerek saklıyoruz.
+                    Her klasörde tarih, oturum sorumlusu ve revizyon notlarının yer aldığı bir kapak belgesi bulunuyor.
+                </p>
+                <p>
+                    Düzenli arşiv tutmak, sonraki toplantılarda referans alabileceğimiz hazır içerikler oluşturuyor ve ekibin tekrar iş üretmesini engelliyor.
+                </p>
+            </article>
+
+            <div class="border-t border-white/10 pt-10">
+                <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" href="insights.html">
+                    <span class="material-icons mr-2 text-sm">west</span>
+                    Tüm yazılara dön
+                </a>
+            </div>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40">İletişim</p>
+                <p>Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400">
+                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Join
+                    </button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p>© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+        const languageSelect = document.getElementById('language-select');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
+    </script>
+</body>
+</html>

--- a/insight-lobi-ilk-izlenim.html
+++ b/insight-lobi-ilk-izlenim.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title>Lobi Sunumunda İlk İzlenim — Alpimimarlık Notları</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black/60 px-8 py-6 backdrop-blur-md md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" for="language-select">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="language-select"
+                >
+                    <option value="tr" selected>TR</option>
+                    <option value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span>Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="mx-auto max-w-4xl space-y-12">
+            <div class="space-y-6">
+                <p class="text-xs uppercase tracking-[0.55em] text-accent">Saha Notu</p>
+                <h1 class="text-4xl font-display text-white md:text-5xl">Lobi Sunumunda İlk İzlenim</h1>
+                <p class="text-sm uppercase tracking-[0.35em] text-white/50">Yayın Tarihi — 18 Ocak 2024</p>
+                <div
+                    aria-label="Lobi sunumu için hazırlanan ışık ve renk kurgusu"
+                    class="ai-visual h-60 w-full"
+                    role="img"
+                    style="background-image: radial-gradient(circle at 22% 30%, rgba(255, 206, 165, 0.8) 0%, rgba(255, 206, 165, 0) 55%), radial-gradient(circle at 78% 65%, rgba(255, 126, 126, 0.45) 0%, rgba(255, 126, 126, 0) 50%), linear-gradient(150deg, #1e1f2d, #101019 58%, #2e2439);"
+                ></div>
+                <p class="text-lg text-white/80">
+                    Lobi sahnesi, küçük bir ofisin kimliğini ilk dakikada aktarması için kullandığımız en güçlü araç. Bu yazı,
+                    hazırladığımız sunum dosyalarında nasıl bir hikâye kurduğumuzu, mekânı tanımlarken hangi öncelikleri göz önünde bulundurduğumuzu anlatıyor.
+                </p>
+            </div>
+
+            <article class="prose prose-invert max-w-none">
+                <h2>Ziyaretçi rotasını netleştirmek</h2>
+                <p>
+                    İlk sunumda kullandığımız plan şemasında, ziyaretçinin girişten toplantı alanına kadar izleyeceği adımları kısaca tarif ediyoruz.
+                    Kapı, danışma ve bekleme alanları arasında net bir rota oluşturmak, müşterinin zihninde mekânın akışını canlandırıyor.
+                    Planın yanında, zemin kaplaması ve yönlendirme elemanları için seçtiğimiz malzemeleri belirtiyoruz.
+                </p>
+                <p>
+                    Bu bölümde gereksiz detaylardan kaçınarak üç ana mesaj iletiyoruz: girişten itibaren hissedilen atmosfer, bekleme alanındaki oturma düzeni ve toplantı odasına geçişte ışığın nasıl değiştiği.
+                    Bu üç başlık, lobiye ilişkin ilk soruları yanıtlıyor ve toplantının ilerleyen dakikalarına sağlam bir zemin hazırlıyor.
+                </p>
+
+                <h2>Işık ve malzeme dengesi</h2>
+                <p>
+                    Lobi anlatımında ışık, mekânı tanıtan ilk görsel ipucu. Gündüz ve akşam senaryoları için iki ayrı aydınlatma şeması hazırlıyoruz.
+                    Gündüz senaryosunda doğal ışığın yoğunluğunu gösteren kısa bir kesit, akşam senaryosunda ise sıcaklığı ayarlanabilir armatürlerin mekâna yayılışını vurgulayan bir kolaj kullanıyoruz.
+                </p>
+                <p>
+                    Malzeme paleti seçimimiz, ışığın anlatmak istediği duyguyu destekliyor. Mat yüzeyler ışığı yumuşatırken, bakır veya pirinç detaylar odağı güçlendiriyor.
+                    Paleti üç ana renkle sınırlamak, anlatımın sade ve anlaşılır kalmasını sağlıyor.
+                </p>
+
+                <h2>Sunum planını yapılandırmak</h2>
+                <p>
+                    Sunum dosyasını hazırlarken lobiyi tek seferde anlatmak yerine kısa adımlara bölüyoruz.
+                    İlk sayfa mekânın duygusunu veren geniş açı, ikinci sayfa kullanıcı deneyimi hikâyesi ve üçüncü sayfa malzeme ile aydınlatma tablosu.
+                    Bu yapı sayesinde toplantı sırasında her bölüm için kısa, net bir açıklama yapabiliyoruz.
+                </p>
+                <p>
+                    Sunumun sonunda, lobinin bitmiş halini temsil eden bir görseli, kontrol listesi ile birlikte paylaşarak görüşmeyi tamamlıyoruz.
+                    Liste; aydınlatma kurulumu, yönlendirme grafikleri ve mobilya yerleşiminden oluşuyor.
+                    Böylece görüşmeden çıkan herkes, yapılacak işlerin sırasını ve beklenen atmosferi aynı şekilde hayal ediyor.
+                </p>
+            </article>
+
+            <div class="border-t border-white/10 pt-10">
+                <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" href="insights.html">
+                    <span class="material-icons mr-2 text-sm">west</span>
+                    Tüm yazılara dön
+                </a>
+            </div>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40">İletişim</p>
+                <p>Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400">
+                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Join
+                    </button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p>© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+        const languageSelect = document.getElementById('language-select');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
+    </script>
+</body>
+</html>

--- a/insight-metinsiz-sahne.html
+++ b/insight-metinsiz-sahne.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title>Metinsiz Sahne Nasıl Anlatılır? — Alpimimarlık Notları</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black/60 px-8 py-6 backdrop-blur-md md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" for="language-select">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="language-select"
+                >
+                    <option value="tr" selected>TR</option>
+                    <option value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span>Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="mx-auto max-w-4xl space-y-12">
+            <div class="space-y-6">
+                <p class="text-xs uppercase tracking-[0.55em] text-accent">Rehber</p>
+                <h1 class="text-4xl font-display text-white md:text-5xl">Metinsiz Sahne Nasıl Anlatılır?</h1>
+                <p class="text-sm uppercase tracking-[0.35em] text-white/50">Yayın Tarihi — 4 Şubat 2024</p>
+                <div
+                    aria-label="Metinsiz sahne anlatımı için kolaj"
+                    class="ai-visual h-60 w-full"
+                    role="img"
+                    style="background-image: radial-gradient(circle at 70% 30%, rgba(160, 214, 255, 0.7) 0%, rgba(160, 214, 255, 0) 55%), radial-gradient(circle at 18% 70%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(160deg, #1a2334, #0f131d 60%, #2a3245);"
+                ></div>
+                <p class="text-lg text-white/80">
+                    Sunum dosyalarında boş kalan sayfaları, metin kullanmadan da etkili bir şekilde kurgulamak mümkün.
+                    Bu rehberde kullandığımız yöntemleri, hikâyeyi kelimeler yerine görsel ipuçlarıyla nasıl güçlendirdiğimizi özetliyoruz.
+                </p>
+            </div>
+
+            <article class="prose prose-invert max-w-none">
+                <h2>Atmosferi kelimeler olmadan kurmak</h2>
+                <p>
+                    Metinsiz sahne anlatımına başlamadan önce, mekânın hangi duyguya odaklandığını belirliyoruz.
+                    Işık yönü, renk paleti ve kullanılan malzemeler bu duygunun temelini oluşturuyor.
+                    Geniş açılı bir görsel yerine, belirli bir noktayı tarif eden üç kare kullanmak, izleyicinin bakışını yönlendiriyor.
+                </p>
+                <p>
+                    Her karede bir ana unsur seçiyoruz: zemin dokusu, oturma düzeni veya cepheye sızan ışık gibi.
+                    Böylece izleyici, sahnenin bütününü kelime okumadan da kavrıyor.
+                </p>
+
+                <h2>Kullanıcı hikâyesi oluşturmak</h2>
+                <p>
+                    Metin yerine kısa bir hikâye kurgulamak için zaman çizelgesi yaklaşımı kullanıyoruz.
+                    Sabah, gün ortası ve akşam senaryolarını üç karede göstererek, mekânın gün boyunca nasıl yaşadığını aktarıyoruz.
+                </p>
+                <p>
+                    Her senaryoda mekânı kullanan kişinin ihtiyacına odaklanan küçük ikonlar veya notlar eklemek, anlatımı destekliyor.
+                    Bunu yaparken tasarımın yalın kalmasına dikkat ediyoruz; her karede tek bir vurgu yeterli oluyor.
+                </p>
+
+                <h2>Kolaj ile son kareyi tamamlamak</h2>
+                <p>
+                    Sahnenin finalini, plan veya kesit üzerine oturttuğumuz kolajla tamamlıyoruz.
+                    Bu kolajda ışık yönlerini, mobilya yerleşimini ve renk yoğunluğunu göstermek için ince çizgiler ve kısa etiketler kullanıyoruz.
+                </p>
+                <p>
+                    Görsel anlatım, toplantı sırasında hızlı geri bildirim alınmasını sağlıyor.
+                    Metin eklemeye gerek kalmadan, sahnenin hangi noktalarının geliştirileceği netleşiyor.
+                </p>
+            </article>
+
+            <div class="border-t border-white/10 pt-10">
+                <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" href="insights.html">
+                    <span class="material-icons mr-2 text-sm">west</span>
+                    Tüm yazılara dön
+                </a>
+            </div>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40">İletişim</p>
+                <p>Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400">
+                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Join
+                    </button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p>© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+        const languageSelect = document.getElementById('language-select');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
+    </script>
+</body>
+</html>

--- a/insights.html
+++ b/insights.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title>Insights — Alpimimarlık</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black/60 px-8 py-6 backdrop-blur-md md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" for="language-select">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="language-select"
+                >
+                    <option value="tr" selected>TR</option>
+                    <option value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span>Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="max-w-5xl space-y-12">
+            <p class="text-xs uppercase tracking-[0.55em] text-accent">Görüşler & Notlar</p>
+            <h1 class="text-4xl font-display text-white md:text-5xl">Alpimimarlık Not Defteri</h1>
+            <p class="text-base text-white/70">
+                Müşterilerle paylaşılacak dosyaları hazırlarken kullandığımız yöntemleri burada toparlıyoruz.
+                Sunum akışı, görsel seçimleri ve küçük ekibimizin çalışma biçimi hakkında notlar içeren kısa makaleler paylaşıyoruz.
+            </p>
+            <div class="space-y-8">
+                <article class="space-y-3 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Lobi sahnesi için hazırlanan renk denemesi"
+                        class="ai-visual h-32 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 22% 30%, rgba(255, 206, 165, 0.8) 0%, rgba(255, 206, 165, 0) 55%), radial-gradient(circle at 78% 65%, rgba(255, 126, 126, 0.45) 0%, rgba(255, 126, 126, 0) 50%), linear-gradient(150deg, #1e1f2d, #101019 58%, #2e2439);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">Saha Notu</p>
+                    <h2 class="text-2xl font-display text-white">Lobi Sunumunda İlk İzlenim</h2>
+                    <p class="text-sm text-white/70">
+                        İlk görüşmede paylaşılan lobi sahnesi, ziyaretçilerin mekânın atmosferini hızla anlamasını sağlıyor. Bizim için çalışan üç temel dokunuşu ve örnek sunum planını anlattık.
+                    </p>
+                    <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" href="insight-lobi-ilk-izlenim.html">
+                        Devamını Oku
+                        <span class="material-icons ml-2 text-sm">east</span>
+                    </a>
+                </article>
+                <article class="space-y-3 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Metinsiz sahne anlatımı için kolaj"
+                        class="ai-visual h-32 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 70% 30%, rgba(160, 214, 255, 0.7) 0%, rgba(160, 214, 255, 0) 55%), radial-gradient(circle at 18% 70%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(160deg, #1a2334, #0f131d 60%, #2a3245);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">Rehber</p>
+                    <h2 class="text-2xl font-display text-white">Metinsiz Sahne Nasıl Anlatılır?</h2>
+                    <p class="text-sm text-white/70">
+                        Görsel olmayan bölümler için kullandığımız üç adımlı strateji: atmosferi kelimelerle kurmak, kullanıcı hikâyesi yazmak ve son kareyi destekleyecek bir kolajla tamamlamak.
+                    </p>
+                    <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" href="insight-metinsiz-sahne.html">
+                        Devamını Oku
+                        <span class="material-icons ml-2 text-sm">east</span>
+                    </a>
+                </article>
+                <article class="space-y-3 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Takım içi sunum oturumu için ışık denemesi"
+                        class="ai-visual h-32 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 50%), radial-gradient(circle at 78% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #141522, #1c1f31 58%, #322544);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">Atölye Özeti</p>
+                    <h2 class="text-2xl font-display text-white">Takım İçi Konsept Oturumları</h2>
+                    <p class="text-sm text-white/70">
+                        Haftalık oturumlarımızda kullandığımız sahne tariflerini, ışık önerilerini ve renk paleti kombinlerini örnek dosyalarla birlikte derledik.
+                    </p>
+                    <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" href="insight-konsept-oturumlari.html">
+                        Devamını Oku
+                        <span class="material-icons ml-2 text-sm">east</span>
+                    </a>
+                </article>
+            </div>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40">İletişim</p>
+                <p>Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400">
+                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Join
+                    </button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p>© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+        const languageSelect = document.getElementById('language-select');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
+    </script>
+</body>
+</html>

--- a/services.html
+++ b/services.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title>Services — Alpimimarlık</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .concept-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .concept-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black/60 px-8 py-6 backdrop-blur-md md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" for="language-select">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="language-select"
+                >
+                    <option value="tr" selected>TR</option>
+                    <option value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span>Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="max-w-5xl space-y-12">
+            <p class="text-xs uppercase tracking-[0.55em] text-accent">Hizmet Paketleri</p>
+            <h1 class="text-4xl font-display text-white md:text-5xl">Sunum Odaklı Mimarlık Servisleri</h1>
+            <p class="text-base text-white/70">
+                Küçük ölçekli ofislerin konseptlerini sahneleyen tanıtım paketleri hazırlıyoruz.
+                Ölçekli çizimler, atmosfer görselleri ve kısa metin blokları, ilk görüşmede güven veren bir vitrin sunmanıza yardımcı oluyor.
+            </p>
+            <div class="grid gap-10 md:grid-cols-2">
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Vizyon kitabı için hazırlanan konsept görsel"
+                        class="concept-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 22% 25%, rgba(255, 206, 165, 0.8) 0%, rgba(255, 206, 165, 0) 55%), radial-gradient(circle at 78% 70%, rgba(255, 132, 132, 0.48) 0%, rgba(255, 132, 132, 0) 50%), linear-gradient(150deg, #1f1f2f, #101019 58%, #2f253a);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">01</p>
+                    <h2 class="text-2xl font-display text-white">Vizyon Kitabı</h2>
+                    <p class="text-sm text-white/70">
+                        Üç bölümlü dijital kitap, lobi, çalışma alanı ve cephe sahnelerini aynı dilde anlatır.
+                        Renderlar ve fotoğraf düzenlemeleri, başlıklarla birlikte kullanılmaya hazır halde teslim edilir.
+                    </p>
+                </div>
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Sunum sahnesi paketine ait storyboard"
+                        class="concept-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 65% 35%, rgba(162, 216, 255, 0.7) 0%, rgba(162, 216, 255, 0) 55%), radial-gradient(circle at 20% 75%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(160deg, #1b2436, #0f141f 60%, #293347);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">02</p>
+                    <h2 class="text-2xl font-display text-white">Sunum Sahnesi</h2>
+                    <p class="text-sm text-white/70">
+                        Pitch toplantıları için hazırlanan bu paket, hareketli slayt akışı ve kısa tanıtım filmiyle desteklenir.
+                        Boş ekranları, ofis kimliğinize uygun kolaj ve plan detaylarıyla tamamlıyoruz.
+                    </p>
+                </div>
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Dijital basın dosyasına ait kolaj"
+                        class="concept-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 50%), radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #131422, #1d1f31 58%, #332645);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">03</p>
+                    <h2 class="text-2xl font-display text-white">Dijital Basın Dosyası</h2>
+                    <p class="text-sm text-white/70">
+                        Basın bültenleri ve sosyal medya lansmanları için hızlıca özelleştirebileceğiniz şablonlar içerir.
+                        Her görsel, stüdyonuzun tonunu anlatan kısa açıklamalarla birlikte gelir.
+                    </p>
+                </div>
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Atölye oturumu için hazırlanan görsel"
+                        class="concept-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 70% 25%, rgba(255, 208, 158, 0.7) 0%, rgba(255, 208, 158, 0) 52%), radial-gradient(circle at 20% 70%, rgba(161, 218, 255, 0.6) 0%, rgba(161, 218, 255, 0) 45%), linear-gradient(155deg, #181a27, #0f1119 58%, #2b253a);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent">04</p>
+                    <h2 class="text-2xl font-display text-white">Danışmanlık & Koordinasyon</h2>
+                    <p class="text-sm text-white/70">
+                        Sunum hazırlıkları sırasında ekiplerinizi yönlendiren toplantılar planlıyoruz.
+                        Malzeme seçimi, metin tonu ve görsel yerleşimleri için paylaşılabilir rehberler sunuyoruz.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40">İletişim</p>
+                <p>Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400">
+                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Join
+                    </button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p>© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+        const languageSelect = document.getElementById('language-select');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
+    </script>
+</body>
+</html>

--- a/studio.html
+++ b/studio.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title>Studio — Alpimimarlık</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .concept-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .concept-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black/60 px-8 py-6 backdrop-blur-md md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" for="language-select">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="language-select"
+                >
+                    <option value="tr" selected>TR</option>
+                    <option value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span>Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="max-w-4xl space-y-10">
+            <p class="text-xs uppercase tracking-[0.55em] text-accent">Stüdyo Hikâyesi</p>
+            <h1 class="text-4xl font-display text-white md:text-5xl">Stüdyonun Arka Planı</h1>
+            <p class="text-base text-white/70">
+                Alpimimarlık, Galata merkezli küçük bir mimarlık ofisi.
+                Tanıtım kitapçıklarında boş kalan bölümleri, ekip içinde hazırladığımız konsept görselleriyle dolduruyor ve sunumların sıcak bir dilde ilerlemesini sağlıyoruz.
+            </p>
+            <div class="grid gap-6 md:grid-cols-3">
+                <figure class="overflow-hidden rounded-sm border border-white/10 bg-black/40">
+                    <div
+                        aria-label="Çalışma masalarının yer aldığı stüdyo görseli"
+                        class="concept-visual h-48"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 25% 25%, rgba(255, 208, 158, 0.8) 0%, rgba(255, 208, 158, 0) 55%), radial-gradient(circle at 75% 70%, rgba(255, 126, 126, 0.5) 0%, rgba(255, 126, 126, 0) 45%), linear-gradient(145deg, #222232, #101019 60%, #30253e);"
+                    ></div>
+                    <figcaption class="p-4 text-xs uppercase tracking-[0.35em] text-white/60">Planlama Odası</figcaption>
+                </figure>
+                <figure class="overflow-hidden rounded-sm border border-white/10 bg-black/40">
+                    <div
+                        aria-label="Giriş holünü gösteren render"
+                        class="concept-visual h-48"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 70% 30%, rgba(160, 214, 255, 0.75) 0%, rgba(160, 214, 255, 0) 55%), radial-gradient(circle at 20% 75%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(150deg, #1b2435, #0f141f 58%, #2a3247);"
+                    ></div>
+                    <figcaption class="p-4 text-xs uppercase tracking-[0.35em] text-white/60">Lobi Vinyeti</figcaption>
+                </figure>
+                <figure class="overflow-hidden rounded-sm border border-white/10 bg-black/40">
+                    <div
+                        aria-label="Gece cephe aydınlatmasını betimleyen görsel"
+                        class="concept-visual h-48"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 20% 70%, rgba(255, 172, 225, 0.55) 0%, rgba(255, 172, 225, 0) 52%), radial-gradient(circle at 80% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #121422, #1c1f31 55%, #302445);"
+                    ></div>
+                    <figcaption class="p-4 text-xs uppercase tracking-[0.35em] text-white/60">Cephe Senaryosu</figcaption>
+                </figure>
+            </div>
+            <div class="space-y-6">
+                <h2 class="text-2xl font-display text-white">Yaklaşımımız</h2>
+                <p class="text-sm text-white/70">
+                    Toplantı öncesi paylaşılan kitapçıklarda, ölçeksiz eskizleri ve stüdyomuzda hazırlanan sahne önerilerini yan yana kurguluyoruz.
+                    Her görsel, mekânın hissini anlatan kısa notlarla destekleniyor.
+                </p>
+                <p class="text-sm text-white/70">
+                    Bu sayede uygulama dosyası tamamlanmadan önce bile yatırımcılara ofisin karakterini net şekilde gösteren tanıtım klasörleri hazırlıyoruz.
+                </p>
+            </div>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40">İletişim</p>
+                <p>Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400">
+                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
+                        Join
+                    </button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p>© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+        const languageSelect = document.getElementById('language-select');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+        if (languageSelect) {
+            languageSelect.addEventListener('change', (event) => {
+                const value = event.target.value;
+                document.documentElement.lang = value === 'en' ? 'en' : 'tr';
+            });
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the top navigation with an Alpimimarlık-branded header and slide-out side menu across every page
- remove the obsolete search overlay and wire the new menu drawer with contact details and navigation links
- update page titles, hero copy, and footers to use the Alpimimarlık name consistently

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68d53a8c5f108325b25812249027112e