### PR TITLE
feat(i18n): add English translations and integrate en.json

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -1,0 +1,191 @@
+(function () {
+    const STORAGE_KEY = 'alpimimarlik-lang';
+    const DEFAULT_LANG = 'tr';
+    const SUPPORTED_LANGS = ['tr', 'en'];
+    const translations = {};
+    let currentLang = DEFAULT_LANG;
+    const changeCallbacks = new Set();
+
+    const resolveKey = (dictionary, key) => {
+        if (!dictionary) return undefined;
+        return key.split('.').reduce((acc, part) => {
+            if (acc && Object.prototype.hasOwnProperty.call(acc, part)) {
+                return acc[part];
+            }
+            return undefined;
+        }, dictionary);
+    };
+
+    const applyValue = (element, value, target) => {
+        if (value === undefined || value === null) return;
+        if (target) {
+            if (target === 'text') {
+                if (element.textContent !== value) {
+                    element.textContent = value;
+                }
+            } else if (target === 'html') {
+                if (element.innerHTML !== value) {
+                    element.innerHTML = value;
+                }
+            } else {
+                if (element.getAttribute(target) !== value) {
+                    element.setAttribute(target, value);
+                }
+            }
+            return;
+        }
+
+        const nodeName = element.nodeName.toLowerCase();
+        if (nodeName === 'input' || nodeName === 'textarea') {
+            if (element.placeholder !== undefined) {
+                if (element.placeholder !== value) {
+                    element.placeholder = value;
+                }
+            } else {
+                if (element.value !== value) {
+                    element.value = value;
+                }
+            }
+            return;
+        }
+
+        if (nodeName === 'title') {
+            if (element.textContent !== value) {
+                element.textContent = value;
+            }
+            return;
+        }
+
+        if (element.textContent !== value) {
+            element.textContent = value;
+        }
+    };
+
+    const applyTranslations = (lang) => {
+        const dictionary = translations[lang];
+        if (!dictionary) return;
+
+        const html = document.documentElement;
+        html.lang = lang;
+        html.dir = resolveKey(dictionary, 'meta.dir') || 'ltr';
+
+        document.querySelectorAll('[data-i18n]').forEach((element) => {
+            const key = element.getAttribute('data-i18n');
+            const target = element.getAttribute('data-i18n-target');
+            applyValue(element, resolveKey(dictionary, key), target);
+        });
+
+        document.querySelectorAll('[data-i18n]').forEach((element) => {
+            Array.from(element.attributes)
+                .filter((attr) => {
+                    if (!attr.name.startsWith('data-i18n-')) return false;
+                    return !['data-i18n', 'data-i18n-target'].includes(attr.name);
+                })
+                .forEach((attr) => {
+                    const attributeName = attr.name.replace('data-i18n-', '');
+                    applyValue(element, resolveKey(dictionary, attr.value), attributeName);
+                });
+        });
+
+        const switcher = document.getElementById('langSwitcher');
+        if (switcher && switcher.value !== lang) {
+            switcher.value = lang;
+        }
+
+        const eventDetail = { lang, dictionary };
+        document.dispatchEvent(new CustomEvent('i18n:change', { detail: eventDetail }));
+        changeCallbacks.forEach((callback) => {
+            try {
+                callback(lang, dictionary);
+            } catch (error) {
+                console.error('i18n callback error:', error);
+            }
+        });
+    };
+
+    const loadDictionary = async (lang) => {
+        if (translations[lang]) {
+            return translations[lang];
+        }
+        const response = await fetch(`i18n/${lang}.json`, { cache: 'no-store' });
+        if (!response.ok) {
+            throw new Error(`Failed to load translations for ${lang}`);
+        }
+        const data = await response.json();
+        translations[lang] = data;
+        return data;
+    };
+
+    const persistLanguage = (lang) => {
+        try {
+            localStorage.setItem(STORAGE_KEY, lang);
+        } catch (error) {
+            console.warn('i18n storage error:', error);
+        }
+    };
+
+    const getStoredLanguage = () => {
+        try {
+            const stored = localStorage.getItem(STORAGE_KEY);
+            if (stored && SUPPORTED_LANGS.includes(stored)) {
+                return stored;
+            }
+        } catch (error) {
+            console.warn('i18n storage error:', error);
+        }
+        return null;
+    };
+
+    const setLanguage = async (lang) => {
+        const targetLang = SUPPORTED_LANGS.includes(lang) ? lang : DEFAULT_LANG;
+        if (currentLang === targetLang && translations[targetLang]) {
+            applyTranslations(targetLang);
+            return;
+        }
+        try {
+            await loadDictionary(targetLang);
+            currentLang = targetLang;
+            persistLanguage(targetLang);
+            applyTranslations(targetLang);
+        } catch (error) {
+            console.error(error);
+            if (targetLang !== DEFAULT_LANG) {
+                await setLanguage(DEFAULT_LANG);
+            }
+        }
+    };
+
+    const init = async () => {
+        const storedLang = getStoredLanguage();
+        const initialLang = storedLang || DEFAULT_LANG;
+        await setLanguage(initialLang);
+        const switcher = document.getElementById('langSwitcher');
+        if (switcher) {
+            switcher.addEventListener('change', (event) => {
+                setLanguage(event.target.value);
+            });
+        }
+    };
+
+    const onChange = (callback) => {
+        if (typeof callback === 'function') {
+            changeCallbacks.add(callback);
+        }
+        if (translations[currentLang]) {
+            callback(currentLang, translations[currentLang]);
+        }
+    };
+
+    window.I18N = {
+        setLanguage,
+        getCurrentLanguage: () => currentLang,
+        onChange,
+        translate: (key) => resolveKey(translations[currentLang], key),
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init, { once: true });
+    } else {
+        init();
+    }
+})();

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title data-i18n="meta.titles.contact">Contact — Alpimimarlık</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .concept-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .concept-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black px-8 py-5 text-white md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white" data-i18n="common.brand">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" data-i18n="common.langLabel" for="langSwitcher">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="langSwitcher"
+                >
+                    <option data-i18n="common.language.tr" value="tr">TR</option>
+                    <option data-i18n="common.language.en" value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span data-i18n="common.menuButton">Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="grid gap-16 md:grid-cols-[2fr,1fr]">
+            <div class="space-y-10">
+                <div
+                    aria-label="Stüdyo girişini anlatan konsept görsel"
+                    class="concept-visual h-48 w-full"
+                    role="img"
+                    style="background-image: radial-gradient(circle at 22% 28%, rgba(255, 208, 158, 0.8) 0%, rgba(255, 208, 158, 0) 55%), radial-gradient(circle at 78% 68%, rgba(161, 218, 255, 0.6) 0%, rgba(161, 218, 255, 0) 48%), linear-gradient(150deg, #1a1c28, #0f1119 60%, #2d253a);"
+                ></div>
+                <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="contact.hero.eyebrow">İletişim</p>
+                <h1 class="text-4xl font-display text-white md:text-5xl" data-i18n="contact.hero.title">Bize Ulaşın</h1>
+                <p class="text-base text-white/70" data-i18n="contact.hero.body">
+                    Kampanya odaklı mimarlık sunumlarımız hakkında konuşmak veya sunum arşivimizi incelemek isterseniz, aşağıdaki formu doldurun.
+                    İlk kez sunum hazırlayan ekipler için hızlı başlangıç oturumu planlıyoruz.
+                </p>
+                <form class="space-y-6">
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label class="block text-xs uppercase tracking-[0.4em] text-white/60" data-i18n="contact.form.nameLabel" for="contact-name">Ad Soyad</label>
+                            <input class="mt-2 w-full border border-white/15 bg-black/40 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none" data-i18n-placeholder="contact.form.namePlaceholder" id="contact-name" placeholder="Adınız Soyadınız" type="text"/>
+                        </div>
+                        <div>
+                            <label class="block text-xs uppercase tracking-[0.4em] text-white/60" data-i18n="contact.form.emailLabel" for="contact-email">E-posta</label>
+                            <input class="mt-2 w-full border border-white/15 bg-black/40 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none" data-i18n-placeholder="contact.form.emailPlaceholder" id="contact-email" placeholder="ornek@studio.com" type="email"/>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-xs uppercase tracking-[0.4em] text-white/60" data-i18n="contact.form.topicLabel" for="contact-topic">Sunum İlgisi</label>
+                        <select class="mt-2 w-full border border-white/15 bg-black/40 p-3 text-sm text-white focus:border-white focus:outline-none" id="contact-topic">
+                            <option data-i18n="contact.form.topicOptions.conceptBook">Konsept kitap hazırlığı</option>
+                            <option data-i18n="contact.form.topicOptions.renderSession">Render ve görselleştirme oturumu</option>
+                            <option data-i18n="contact.form.topicOptions.launchSet">Dijital lansman seti</option>
+                            <option data-i18n="contact.form.topicOptions.other">Diğer</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-xs uppercase tracking-[0.4em] text-white/60" data-i18n="contact.form.messageLabel" for="contact-message">Mesajınız</label>
+                        <textarea class="mt-2 h-32 w-full border border-white/15 bg-black/40 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none" data-i18n-placeholder="contact.form.messagePlaceholder" id="contact-message" placeholder="Ekibinizin ihtiyacını kısaca anlatın..."></textarea>
+                    </div>
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" data-i18n="contact.form.submit" type="submit">
+                        Gönder
+                    </button>
+                </form>
+            </div>
+            <aside class="space-y-8 border border-white/10 bg-black/30 p-6">
+                <div
+                    aria-label="Galata stüdyo atmosferini anlatan konsept görsel"
+                    class="concept-visual h-32 w-full"
+                    role="img"
+                    style="background-image: radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 48%), radial-gradient(circle at 78% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #131522, #1d1f31 58%, #302544);"
+                ></div>
+                <div class="space-y-2">
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="contact.aside.studio.label">Stüdyo</p>
+                    <p class="text-sm text-white/70" data-i18n="contact.aside.studio.location">Istanbul, Galata</p>
+                    <p class="text-sm text-white/60" data-i18n="contact.aside.studio.hours">Hafta içi 10:00 - 18:00 arası randevu ile görüşme sağlanır.</p>
+                </div>
+                <div class="space-y-2">
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="contact.aside.phone.label">Telefon</p>
+                    <a class="text-sm text-white/70 transition hover:text-white" data-i18n="contact.aside.phone.number" href="tel:+902122223344">+90 212 222 33 44</a>
+                </div>
+                <div class="space-y-2">
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="contact.aside.email.label">E-posta</p>
+                    <a class="text-sm text-white/70 transition hover:text-white" data-i18n="contact.aside.email.address" href="mailto:iletisim@alpimimarlik.com">iletisim@alpimimarlik.com</a>
+                </div>
+                <div class="space-y-2">
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="contact.aside.archive.label">Sunum Arşivi</p>
+                    <p class="text-sm text-white/60" data-i18n="contact.aside.archive.body">
+                        Sunum öncesi paylaşılacak örnek görseller için özel bir galeri bağlantısı oluşturuyoruz. Talep formunda belirtin.
+                    </p>
+                </div>
+            </aside>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="common.brand" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white" data-i18n="common.menuPanel.title">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html" data-i18n="common.nav.home">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html" data-i18n="common.nav.studio">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html" data-i18n="common.nav.services">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html" data-i18n="common.nav.insights">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html" data-i18n="common.nav.contact">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40" data-i18n="common.menuPanel.contactHeading">İletişim</p>
+                <p data-i18n="common.menuPanel.contactBody">Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white" data-i18n="common.footer.title">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400" data-i18n="common.footer.tagline">                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.navigate">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html" data-i18n="common.nav.home">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html" data-i18n="common.nav.studio">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html" data-i18n="common.nav.services">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html" data-i18n="common.nav.insights">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html" data-i18n="common.nav.contact">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.connect">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.instagram">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.linkedin">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.behance">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.youtube">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.newsletter">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        data-i18n-placeholder="common.footer.newsletterPlaceholder" placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit" data-i18n="common.footer.newsletterButton">Join</button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p data-i18n="common.footer.copyright">© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/i18n.js"></script>
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+    </script>
+</body>
+</html>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,341 @@
+{
+  "meta": {
+    "dir": "ltr",
+    "titles": {
+      "home": "Alpimimarlık — Home",
+      "studio": "Studio — Alpimimarlık",
+      "services": "Services — Alpimimarlık",
+      "insights": "Insights — Alpimimarlık",
+      "contact": "Contact — Alpimimarlık",
+      "careers": "Careers — Alpimimarlık",
+      "insightLobby": "Lobby First Impressions — Alpimimarlık Notes",
+      "insightScene": "How to Tell a Scene Without Text — Alpimimarlık Notes",
+      "insightSessions": "In-Studio Concept Sessions — Alpimimarlık Notes"
+    }
+  },
+  "common": {
+    "brand": "Alpimimarlık",
+    "langLabel": "Language",
+    "language": {
+      "tr": "TR",
+      "en": "EN"
+    },
+    "menuButton": "Menu",
+    "nav": {
+      "home": "Home",
+      "studio": "Studio",
+      "services": "Services",
+      "insights": "Insights",
+      "careers": "Careers",
+      "contact": "Contact"
+    },
+    "menuPanel": {
+      "title": "Showcase Menu",
+      "contactHeading": "Contact",
+      "contactBody": "Galata-based studio crafting presentation booklets.",
+      "email": "iletisim@alpimimarlik.com"
+    },
+    "footer": {
+      "title": "Alpimimarlık",
+      "tagline": "Pioneering architectural narratives shaped by context, craft, and human experience.",
+      "navigate": "Navigate",
+      "connect": "Connect",
+      "newsletter": "Newsletter",
+      "newsletterPlaceholder": "Enter your email",
+      "newsletterButton": "Join",
+      "instagram": "Instagram",
+      "linkedin": "LinkedIn",
+      "behance": "Behance",
+      "youtube": "YouTube",
+      "copyright": "© 2024 Alpimimarlık. All rights reserved."
+    }
+  },
+  "index": {
+    "hero": {
+      "scrollHint": "Scroll to explore",
+      "slide1": {
+        "category": "Campaign Showcase",
+        "title": "Sunrise Studio Composition",
+        "description": "Daylight-bathed work islands bring the calm yet productive tempo of our new office into the spotlight.",
+        "location": "Main Studio"
+      },
+      "slide2": {
+        "category": "Launch Moment",
+        "title": "Soft-Lit Welcome",
+        "description": "The pairing of natural stone and gentle lighting turns the lobby into an inviting scene coloured with our warm tones.",
+        "location": "Lobby"
+      },
+      "slide3": {
+        "category": "Night Scenario",
+        "title": "Evening Façade",
+        "description": "City-facing lights carry the refined evening posture of our office across the skyline.",
+        "location": "City Silhouette"
+      }
+    },
+    "vision": {
+      "eyebrow": "Studio Vision",
+      "title": "Alpimimarlık's Presentation Approach",
+      "body1": "We share our projects through concise presentations complemented by detailed model work. The visual decks we prepare showcase our sense of scale and warm voice alongside short promotional copy.",
+      "body2": "Each folder covers atmosphere narratives from the opening scene to the night façade. Sketches and model photographs shared during preparation preserve the tone and accelerate the team's promotional steps."
+    }
+  },
+  "studio": {
+    "hero": {
+      "eyebrow": "Studio Story",
+      "title": "Behind the Studio",
+      "body": "Alpimimarlık is a small Galata-based architecture studio. We fill the empty pockets in presentation booklets with in-house concept visuals so every deck carries a warm tone."
+    },
+    "gallery": {
+      "caption1": "Planning Room",
+      "caption2": "Lobby Vignette",
+      "caption3": "Façade Scenario"
+    },
+    "approach": {
+      "title": "Our Approach",
+      "body1": "Before meetings we pair rough sketches with scenes prepared in our studio. Each visual is supported by short notes describing the mood of the space.",
+      "body2": "This lets us present folders that clearly convey the office character even before the construction set is complete."
+    }
+  },
+  "services": {
+    "hero": {
+      "eyebrow": "Service Packages",
+      "title": "Presentation-Focused Architecture Services",
+      "body": "We craft launch-ready packages that stage the concepts of small-scale studios. Drawings, atmosphere visuals, and concise copy help you offer a trusted showcase in first meetings."
+    },
+    "packages": {
+      "visionBook": {
+        "index": "01",
+        "title": "Vision Book",
+        "body": "A three-part digital book narrates the lobby, work zone, and façade in a unified tone. Renders and edited photos arrive ready to use with headlines."
+      },
+      "presentationScene": {
+        "index": "02",
+        "title": "Presentation Scene",
+        "body": "Designed for pitch meetings, this set couples a motion-ready slide flow with a short teaser film. We complete empty screens with collages and plans that match your studio identity."
+      },
+      "pressKit": {
+        "index": "03",
+        "title": "Digital Press Kit",
+        "body": "Includes templates you can quickly tailor for press briefings and social launches. Each visual is paired with captions that convey your studio's tone."
+      },
+      "consulting": {
+        "index": "04",
+        "title": "Consulting & Coordination",
+        "body": "We schedule sessions that guide your team during preparation. Shareable guides cover material choices, voice, and visual placement."
+      }
+    }
+  },
+  "insights": {
+    "hero": {
+      "eyebrow": "Insights & Notes",
+      "title": "Alpimimarlık Notebook",
+      "body": "We collect the methods we rely on while preparing client-ready files. Short articles share notes on presentation flow, visual selection, and how our small team works."
+    },
+    "articles": {
+      "lobby": {
+        "label": "Field Note",
+        "title": "First Impressions in the Lobby",
+        "excerpt": "The lobby scene helps visitors grasp the atmosphere within minutes. We outlined three key touches that work for us and the sample presentation plan.",
+        "link": "Read More"
+      },
+      "scene": {
+        "label": "Guide",
+        "title": "How to Convey a Wordless Scene",
+        "excerpt": "Our three-step strategy for pages without text: set the mood, write a user vignette, and finish with a supporting collage.",
+        "link": "Read More"
+      },
+      "sessions": {
+        "label": "Workshop Recap",
+        "title": "In-Studio Concept Sessions",
+        "excerpt": "We compiled the scene descriptions, lighting tips, and palette pairings we use in weekly sessions with sample files.",
+        "link": "Read More"
+      }
+    }
+  },
+  "insightLobby": {
+    "hero": {
+      "label": "Field Note",
+      "title": "First Impressions in the Lobby",
+      "meta": "Published — 18 January 2024",
+      "intro": "The lobby scene is our strongest tool for communicating a small office's character in the first minute. This article explains the narrative we build and the priorities we focus on when defining the space."
+    },
+    "sections": {
+      "route": {
+        "heading": "Clarifying the visitor route",
+        "paragraph1": "In our initial plan diagram we briefly describe the steps from entry to meeting area. A clear path between the door, reception, and lounge helps clients imagine the flow.",
+        "paragraph2": "We keep to three core points: the atmosphere at the entrance, the seating layout in the lounge, and how light shifts on the way to the meeting room. Together they answer the first questions about the lobby and set the stage for the rest of the session."
+      },
+      "light": {
+        "heading": "Balancing light and material",
+        "paragraph1": "Light is the first visual cue in our lobby narrative. We prepare separate schemes for day and evening scenarios—one section highlighting daylight levels and another collage showing how adjustable fixtures spread through the space.",
+        "paragraph2": "The material palette reinforces the emotion we want the light to convey. Matte surfaces soften it, while brass or copper details sharpen the focal points. Limiting the palette to three main tones keeps the story clear."
+      },
+      "structure": {
+        "heading": "Structuring the presentation",
+        "paragraph1": "We break the lobby story into short steps instead of covering everything at once. The first page sets the mood with a wide angle, the second narrates the user experience, and the third summarises materials and lighting.",
+        "paragraph2": "We close with a finished view and checklist covering lighting setup, wayfinding graphics, and furniture placement. Everyone leaves the meeting with the same understanding of order and expected atmosphere."
+      }
+    },
+    "backLink": "Back to all articles"
+  },
+  "insightScene": {
+    "hero": {
+      "label": "Guide",
+      "title": "How to Tell a Scene Without Text",
+      "meta": "Published — 4 February 2024",
+      "intro": "It is possible to design the empty pages in a presentation without adding copy. This guide summarises how we strengthen the story using visual cues instead of words."
+    },
+    "sections": {
+      "atmosphere": {
+        "heading": "Building atmosphere without words",
+        "paragraph1": "Before we start, we decide which feeling the space should deliver. Light direction, palette, and materials form the base. Rather than a wide angle, we use three frames to steer the viewer's eye.",
+        "paragraph2": "Each frame focuses on one element—the floor texture, seating, or the light slipping along the façade—so the audience grasps the whole scene without reading text."
+      },
+      "story": {
+        "heading": "Shaping the user story",
+        "paragraph1": "We switch to a timeline approach to build a story without copy. Morning, midday, and evening scenarios show how the space is used throughout the day.",
+        "paragraph2": "Small icons or notes tied to the user's needs support the visuals. Keeping the design minimal—one highlight per frame—prevents overload."
+      },
+      "collage": {
+        "heading": "Finishing with a collage",
+        "paragraph1": "We conclude the scene with a collage placed over a plan or section. Thin lines and short labels indicate light directions, furniture placement, and colour intensity.",
+        "paragraph2": "The visual approach invites quick feedback during meetings and reveals which parts need refinement without adding text."
+      }
+    },
+    "backLink": "Back to all articles"
+  },
+  "insightSessions": {
+    "hero": {
+      "label": "Workshop Recap",
+      "title": "In-Studio Concept Sessions",
+      "meta": "Published — 26 February 2024",
+      "intro": "Our weekly concept sessions keep presentation files consistent and moving quickly. This article explains how we plan them, the outputs we expect, and how we share responsibilities."
+    },
+    "sections": {
+      "schedule": {
+        "heading": "Session flow",
+        "paragraph1": "Each meeting is structured in 45-minute blocks. One person presents the latest deck while the others listen and note questions.",
+        "paragraph2": "Notes are documented within 24 hours in a short summary so everyone sees the tasks and deadlines clearly."
+      },
+      "checklist": {
+        "heading": "Visual checklist",
+        "paragraph1": "The second block reviews visual consistency—palette, light direction, and material storytelling under three headings. We assign owners for missing items with quick turnarounds.",
+        "paragraph2": "This keeps every deck speaking the same language even when multiple team members contribute."
+      },
+      "archive": {
+        "heading": "Archiving and sharing",
+        "paragraph1": "We store every visual and file on a shared server at the end of the session. Each folder includes a cover sheet with the date, owner, and revision notes.",
+        "paragraph2": "Maintaining a clear archive gives us ready references for future meetings and avoids duplicate work."
+      }
+    },
+    "backLink": "Back to all articles"
+  },
+  "careers": {
+    "intro": {
+      "eyebrow": "Careers",
+      "title": "Join Presentation-Focused Practice",
+      "body": "Alpimimarlık is a small, disciplined team managing concept presentations, model shoots, and pre-site communication. We look for curious teammates to strengthen the visual stories prepared in our Galata studio."
+    },
+    "values": {
+      "rhythm": {
+        "label": "Cadence",
+        "title": "Workshop Tempo",
+        "body": "We spend four days together in the studio and one remote day for shared sketch sessions. Presentation files circulate within the team so revisions move fast."
+      },
+      "mentoring": {
+        "label": "Mentoring",
+        "title": "Learning Together",
+        "body": "New teammates join one-on-one reviews with the founding partners. We develop every presentation template collaboratively."
+      },
+      "atmosphere": {
+        "label": "Atmosphere",
+        "title": "Warm Studio",
+        "body": "A close-knit crew brings Galata's rhythm into the studio. The model table, sound system, and photo corner are always ready."
+      }
+    },
+    "roles": {
+      "eyebrow": "Open Positions",
+      "title": "Roles We're Hiring",
+      "description": "Share your portfolio, a short motivation letter, and contact details for the roles below and we respond within a week.",
+      "cta": "Send Application",
+      "positions": {
+        "presentationArchitect": {
+          "title": "Presentation Architect",
+          "body": "You'll prepare plans, sections, and atmosphere boards for concept meetings and bring model photography into a catalogue language. Experience with Rhino, Enscape, and Adobe InDesign is expected.",
+          "bullets": {
+            "one": "• 2–4 years of architectural presentation experience",
+            "two": "• Ability to write detailed Turkish copy and short English summaries",
+            "three": "• Participation in pre-construction meetings"
+          }
+        },
+        "visualDesigner": {
+          "title": "Visual Communication Designer",
+          "body": "We'll co-design posters, social layouts, and covers for launch campaigns. We're looking for someone who preserves our design voice while proposing fresh typography.",
+          "bullets": {
+            "one": "• Adobe Illustrator and Figma experience",
+            "two": "• Comfort working with architectural imagery",
+            "three": "• Open to short-term freelance collaboration"
+          }
+        },
+        "studioIntern": {
+          "title": "Studio Intern",
+          "body": "During summer you will support sketch and model workflows and organise presentation folders before meetings. We'd like to see the narrative voice in your studio projects.",
+          "bullets": {
+            "one": "• Third or fourth year architecture student",
+            "two": "• Availability for at least three studio days per week",
+            "three": "• Precision in model making"
+          }
+        }
+      }
+    },
+    "application": {
+      "eyebrow": "Application",
+      "title": "How to Apply",
+      "body1": "Prepare your portfolio as a PDF of up to 15 pages. In your motivation letter, share the type of presentation you would like to build with the Alpimimarlık team. Include contact details for tutors or collaborators who can provide references.",
+      "body2": "Send your application to kariyer@alpimimarlik.com. We follow up within a week to schedule a meeting or share portfolio feedback.",
+      "cta": "Share Application"
+    }
+  },
+  "contact": {
+    "hero": {
+      "eyebrow": "Contact",
+      "title": "Get in Touch",
+      "body": "Fill in the form to talk about our campaign-focused presentations or to request access to our archive. We schedule a quick starter session for teams preparing their first presentation."
+    },
+    "form": {
+      "nameLabel": "Full Name",
+      "namePlaceholder": "Your name",
+      "emailLabel": "Email",
+      "emailPlaceholder": "sample@studio.com",
+      "topicLabel": "Presentation Interest",
+      "topicOptions": {
+        "conceptBook": "Preparing a concept book",
+        "renderSession": "Render and visualization session",
+        "launchSet": "Digital launch set",
+        "other": "Other"
+      },
+      "messageLabel": "Your Message",
+      "messagePlaceholder": "Tell us briefly about your team's needs...",
+      "submit": "Send"
+    },
+    "aside": {
+      "studio": {
+        "label": "Studio",
+        "location": "Istanbul, Galata",
+        "hours": "Meetings by appointment on weekdays between 10:00 and 18:00."
+      },
+      "phone": {
+        "label": "Phone",
+        "number": "+90 212 222 33 44"
+      },
+      "email": {
+        "label": "Email",
+        "address": "iletisim@alpimimarlik.com"
+      },
+      "archive": {
+        "label": "Presentation Archive",
+        "body": "We create a private gallery link for sample visuals shared ahead of meetings. Please mention it in the form."
+      }
+    }
+  }
+}

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -1,0 +1,341 @@
+{
+  "meta": {
+    "dir": "ltr",
+    "titles": {
+      "home": "Alpimimarlık — Ana Sayfa",
+      "studio": "Studio — Alpimimarlık",
+      "services": "Services — Alpimimarlık",
+      "insights": "Insights — Alpimimarlık",
+      "contact": "Contact — Alpimimarlık",
+      "careers": "Kariyer — Alpimimarlık",
+      "insightLobby": "Lobi Sunumunda İlk İzlenim — Alpimimarlık Notları",
+      "insightScene": "Metinsiz Sahne Nasıl Anlatılır? — Alpimimarlık Notları",
+      "insightSessions": "Takım İçi Konsept Oturumları — Alpimimarlık Notları"
+    }
+  },
+  "common": {
+    "brand": "Alpimimarlık",
+    "langLabel": "Dil Seçimi",
+    "language": {
+      "tr": "TR",
+      "en": "EN"
+    },
+    "menuButton": "Menü",
+    "nav": {
+      "home": "Ana Sayfa",
+      "studio": "Stüdyo",
+      "services": "Hizmetler",
+      "insights": "Notlar",
+      "careers": "Kariyer",
+      "contact": "İletişim"
+    },
+    "menuPanel": {
+      "title": "Tanıtım Menüsü",
+      "contactHeading": "İletişim",
+      "contactBody": "Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.",
+      "email": "iletisim@alpimimarlik.com"
+    },
+    "footer": {
+      "title": "Alpimimarlık",
+      "tagline": "Bağlam, zanaat ve insan deneyimiyle şekillenen mimari anlatılar.",
+      "navigate": "Gezin",
+      "connect": "İletişim",
+      "newsletter": "Bülten",
+      "newsletterPlaceholder": "E-posta adresinizi girin",
+      "newsletterButton": "Katıl",
+      "instagram": "Instagram",
+      "linkedin": "LinkedIn",
+      "behance": "Behance",
+      "youtube": "YouTube",
+      "copyright": "© 2024 Alpimimarlık. Tüm hakları saklıdır."
+    }
+  },
+  "index": {
+    "hero": {
+      "scrollHint": "Keşfetmek için kaydırın",
+      "slide1": {
+        "category": "Kampanya Vitrini",
+        "title": "Gün Doğumu Stüdyo Kurgusu",
+        "description": "Gün ışığıyla nefes alan çalışma adaları, yeni ofisimizin sakin ama üretken temposunu sahne ışığı altına taşıyor.",
+        "location": "Merkez Stüdyo"
+      },
+      "slide2": {
+        "category": "Mekân Lansmanı",
+        "title": "Yumuşak Işıkta Karşılama",
+        "description": "Doğal taş ve yumuşak aydınlatma birlikteliği, giriş holünü markamızın sıcak tonlarıyla buluşturan davetkâr bir sahneye dönüştürüyor.",
+        "location": "Giriş Holü"
+      },
+      "slide3": {
+        "category": "Gece Senaryosu",
+        "title": "Akşam Cephesi",
+        "description": "Kentin ritmine eşlik eden cephe ışıkları, ofisimizin akşam saatlerindeki rafine duruşunu panoramaya taşıyor.",
+        "location": "Kent Silueti"
+      }
+    },
+    "vision": {
+      "eyebrow": "Stüdyo Vizyonu",
+      "title": "Alpimimarlık'ın Sunum Yaklaşımı",
+      "body1": "Projelerimizi yalın anlatımlı sunumlar ve detaylı maket çalışmaları eşliğinde paylaşıyoruz. Hazırladığımız görsel sunumlar, ofisimizin ölçekli düşünme becerisini ve samimi iletişim dilini kısa tanıtım metinleriyle birlikte ortaya koymayı hedefliyor.",
+      "body2": "Her sunum klasöründe, giriş sahnesinden gece cephe kurgusuna kadar uzanan atmosfer anlatıları yer alıyor. Hazırlık sürecinde paylaştığımız eskizler ve maket fotoğrafları, anlatının tonunu koruyarak ekiplerin tanıtım adımlarını hızlandırıyor."
+    }
+  },
+  "studio": {
+    "hero": {
+      "eyebrow": "Stüdyo Hikâyesi",
+      "title": "Stüdyonun Arka Planı",
+      "body": "Alpimimarlık, Galata merkezli küçük bir mimarlık ofisi. Tanıtım kitapçıklarında boş kalan bölümleri, ekip içinde hazırladığımız konsept görselleriyle dolduruyor ve sunumların sıcak bir dilde ilerlemesini sağlıyoruz."
+    },
+    "gallery": {
+      "caption1": "Planlama Odası",
+      "caption2": "Lobi Vinyeti",
+      "caption3": "Cephe Senaryosu"
+    },
+    "approach": {
+      "title": "Yaklaşımımız",
+      "body1": "Toplantı öncesi paylaşılan kitapçıklarda, ölçeksiz eskizleri ve stüdyomuzda hazırlanan sahne önerilerini yan yana kurguluyoruz. Her görsel, mekânın hissini anlatan kısa notlarla destekleniyor.",
+      "body2": "Bu sayede uygulama dosyası tamamlanmadan önce bile yatırımcılara ofisin karakterini net şekilde gösteren tanıtım klasörleri hazırlıyoruz."
+    }
+  },
+  "services": {
+    "hero": {
+      "eyebrow": "Hizmet Paketleri",
+      "title": "Sunum Odaklı Mimarlık Servisleri",
+      "body": "Küçük ölçekli ofislerin konseptlerini sahneleyen tanıtım paketleri hazırlıyoruz. Ölçekli çizimler, atmosfer görselleri ve kısa metin blokları, ilk görüşmede güven veren bir vitrin sunmanıza yardımcı oluyor."
+    },
+    "packages": {
+      "visionBook": {
+        "index": "01",
+        "title": "Vizyon Kitabı",
+        "body": "Üç bölümlü dijital kitap, lobi, çalışma alanı ve cephe sahnelerini aynı dilde anlatır. Renderlar ve fotoğraf düzenlemeleri, başlıklarla birlikte kullanılmaya hazır halde teslim edilir."
+      },
+      "presentationScene": {
+        "index": "02",
+        "title": "Sunum Sahnesi",
+        "body": "Pitch toplantıları için hazırlanan bu paket, hareketli slayt akışı ve kısa tanıtım filmiyle desteklenir. Boş ekranları, ofis kimliğinize uygun kolaj ve plan detaylarıyla tamamlıyoruz."
+      },
+      "pressKit": {
+        "index": "03",
+        "title": "Dijital Basın Dosyası",
+        "body": "Basın bültenleri ve sosyal medya lansmanları için hızlıca özelleştirebileceğiniz şablonlar içerir. Her görsel, stüdyonuzun tonunu anlatan kısa açıklamalarla birlikte gelir."
+      },
+      "consulting": {
+        "index": "04",
+        "title": "Danışmanlık & Koordinasyon",
+        "body": "Sunum hazırlıkları sırasında ekiplerinizi yönlendiren toplantılar planlıyoruz. Malzeme seçimi, metin tonu ve görsel yerleşimleri için paylaşılabilir rehberler sunuyoruz."
+      }
+    }
+  },
+  "insights": {
+    "hero": {
+      "eyebrow": "Görüşler & Notlar",
+      "title": "Alpimimarlık Not Defteri",
+      "body": "Müşterilerle paylaşılacak dosyaları hazırlarken kullandığımız yöntemleri burada toparlıyoruz. Sunum akışı, görsel seçimleri ve küçük ekibimizin çalışma biçimi hakkında notlar içeren kısa makaleler paylaşıyoruz."
+    },
+    "articles": {
+      "lobby": {
+        "label": "Saha Notu",
+        "title": "Lobi Sunumunda İlk İzlenim",
+        "excerpt": "İlk görüşmede paylaşılan lobi sahnesi, ziyaretçilerin mekânın atmosferini hızla anlamasını sağlıyor. Bizim için çalışan üç temel dokunuşu ve örnek sunum planını anlattık.",
+        "link": "Devamını Oku"
+      },
+      "scene": {
+        "label": "Rehber",
+        "title": "Metinsiz Sahne Nasıl Anlatılır?",
+        "excerpt": "Görsel olmayan bölümler için kullandığımız üç adımlı strateji: atmosferi kelimelerle kurmak, kullanıcı hikâyesi yazmak ve son kareyi destekleyecek bir kolajla tamamlamak.",
+        "link": "Devamını Oku"
+      },
+      "sessions": {
+        "label": "Atölye Özeti",
+        "title": "Takım İçi Konsept Oturumları",
+        "excerpt": "Haftalık oturumlarımızda kullandığımız sahne tariflerini, ışık önerilerini ve renk paleti kombinlerini örnek dosyalarla birlikte derledik.",
+        "link": "Devamını Oku"
+      }
+    }
+  },
+  "insightLobby": {
+    "hero": {
+      "label": "Saha Notu",
+      "title": "Lobi Sunumunda İlk İzlenim",
+      "meta": "Yayın Tarihi — 18 Ocak 2024",
+      "intro": "Lobi sahnesi, küçük bir ofisin kimliğini ilk dakikada aktarması için kullandığımız en güçlü araç. Bu yazı, hazırladığımız sunum dosyalarında nasıl bir hikâye kurduğumuzu, mekânı tanımlarken hangi öncelikleri göz önünde bulundurduğumuzu anlatıyor."
+    },
+    "sections": {
+      "route": {
+        "heading": "Ziyaretçi rotasını netleştirmek",
+        "paragraph1": "İlk sunumda kullandığımız plan şemasında, ziyaretçinin girişten toplantı alanına kadar izleyeceği adımları kısaca tarif ediyoruz. Kapı, danışma ve bekleme alanları arasında net bir rota oluşturmak, müşterinin zihninde mekânın akışını canlandırıyor. Planın yanında, zemin kaplaması ve yönlendirme elemanları için seçtiğimiz malzemeleri belirtiyoruz.",
+        "paragraph2": "Bu bölümde gereksiz detaylardan kaçınarak üç ana mesaj iletiyoruz: girişten itibaren hissedilen atmosfer, bekleme alanındaki oturma düzeni ve toplantı odasına geçişte ışığın nasıl değiştiği. Bu üç başlık, lobiye ilişkin ilk soruları yanıtlıyor ve toplantının ilerleyen dakikalarına sağlam bir zemin hazırlıyor."
+      },
+      "light": {
+        "heading": "Işık ve malzeme dengesi",
+        "paragraph1": "Lobi anlatımında ışık, mekânı tanıtan ilk görsel ipucu. Gündüz ve akşam senaryoları için iki ayrı aydınlatma şeması hazırlıyoruz. Gündüz senaryosunda doğal ışığın yoğunluğunu gösteren kısa bir kesit, akşam senaryosunda ise sıcaklığı ayarlanabilir armatürlerin mekâna yayılışını vurgulayan bir kolaj kullanıyoruz.",
+        "paragraph2": "Malzeme paleti seçimimiz, ışığın anlatmak istediği duyguyu destekliyor. Mat yüzeyler ışığı yumuşatırken, bakır veya pirinç detaylar odağı güçlendiriyor. Paleti üç ana renkle sınırlamak, anlatımın sade ve anlaşılır kalmasını sağlıyor."
+      },
+      "structure": {
+        "heading": "Sunum planını yapılandırmak",
+        "paragraph1": "Sunum dosyasını hazırlarken lobiyi tek seferde anlatmak yerine kısa adımlara bölüyoruz. İlk sayfa mekânın duygusunu veren geniş açı, ikinci sayfa kullanıcı deneyimi hikâyesi ve üçüncü sayfa malzeme ile aydınlatma tablosu. Bu yapı sayesinde toplantı sırasında her bölüm için kısa, net bir açıklama yapabiliyoruz.",
+        "paragraph2": "Sunumun sonunda, lobinin bitmiş halini temsil eden bir görseli, kontrol listesi ile birlikte paylaşarak görüşmeyi tamamlıyoruz. Liste; aydınlatma kurulumu, yönlendirme grafikleri ve mobilya yerleşiminden oluşuyor. Böylece görüşmeden çıkan herkes, yapılacak işlerin sırasını ve beklenen atmosferi aynı şekilde hayal ediyor."
+      }
+    },
+    "backLink": "Tüm yazılara dön"
+  },
+  "insightScene": {
+    "hero": {
+      "label": "Rehber",
+      "title": "Metinsiz Sahne Nasıl Anlatılır?",
+      "meta": "Yayın Tarihi — 4 Şubat 2024",
+      "intro": "Sunum dosyalarında boş kalan sayfaları, metin kullanmadan da etkili bir şekilde kurgulamak mümkün. Bu rehberde kullandığımız yöntemleri, hikâyeyi kelimeler yerine görsel ipuçlarıyla nasıl güçlendirdiğimizi özetliyoruz."
+    },
+    "sections": {
+      "atmosphere": {
+        "heading": "Atmosferi kelimeler olmadan kurmak",
+        "paragraph1": "Metinsiz sahne anlatımına başlamadan önce, mekânın hangi duyguya odaklandığını belirliyoruz. Işık yönü, renk paleti ve kullanılan malzemeler bu duygunun temelini oluşturuyor. Geniş açılı bir görsel yerine, belirli bir noktayı tarif eden üç kare kullanmak, izleyicinin bakışını yönlendiriyor.",
+        "paragraph2": "Her karede bir ana unsur seçiyoruz: zemin dokusu, oturma düzeni veya cepheye sızan ışık gibi. Böylece izleyici, sahnenin bütününü kelime okumadan da kavrıyor."
+      },
+      "story": {
+        "heading": "Kullanıcı hikâyesi oluşturmak",
+        "paragraph1": "Metin yerine kısa bir hikâye kurgulamak için zaman çizelgesi yaklaşımı kullanıyoruz. Sabah, gün ortası ve akşam senaryolarını üç karede göstererek, mekânın gün boyunca nasıl yaşadığını aktarıyoruz.",
+        "paragraph2": "Her senaryoda mekânı kullanan kişinin ihtiyacına odaklanan küçük ikonlar veya notlar eklemek, anlatımı destekliyor. Bunu yaparken tasarımın yalın kalmasına dikkat ediyoruz; her karede tek bir vurgu yeterli oluyor."
+      },
+      "collage": {
+        "heading": "Kolaj ile son kareyi tamamlamak",
+        "paragraph1": "Sahnenin finalini, plan veya kesit üzerine oturttuğumuz kolajla tamamlıyoruz. Bu kolajda ışık yönlerini, mobilya yerleşimini ve renk yoğunluğunu göstermek için ince çizgiler ve kısa etiketler kullanıyoruz.",
+        "paragraph2": "Görsel anlatım, toplantı sırasında hızlı geri bildirim alınmasını sağlıyor. Metin eklemeye gerek kalmadan, sahnenin hangi noktalarının geliştirileceği netleşiyor."
+      }
+    },
+    "backLink": "Tüm yazılara dön"
+  },
+  "insightSessions": {
+    "hero": {
+      "label": "Atölye Özeti",
+      "title": "Takım İçi Konsept Oturumları",
+      "meta": "Yayın Tarihi — 26 Şubat 2024",
+      "intro": "Haftalık olarak yaptığımız konsept oturumları, sunum dosyalarımızın tutarlı ve hızlı bir şekilde gelişmesini sağlıyor. Bu yazı, oturumların nasıl planlandığını, hangi çıktıları beklediğimizi ve ekip içinde görev paylaşımını nasıl yaptığımızı açıklıyor."
+    },
+    "sections": {
+      "schedule": {
+        "heading": "Toplantı düzeni",
+        "paragraph1": "Her oturum, 45 dakikalık zaman bloklarından oluşuyor. İlk bölümde bir kişi güncel sunum taslağını paylaşıyor. Diğer ekip üyeleri sorularını not alarak sadece dinliyor. Sunum tamamlandıktan sonra soruları sırayla yanıtlıyor ve gerekli revizyonları birlikte işaretliyoruz.",
+        "paragraph2": "Oturumda alınan notlar, toplantı sonrası 24 saat içinde paylaşılan kısa bir özetle dokümante ediliyor. Böylece herkes yapılacak işleri ve teslim tarihlerini net olarak görüyor."
+      },
+      "checklist": {
+        "heading": "Görsel kontrol listesi",
+        "paragraph1": "Her oturumun ikinci bölümünde, görsellerin tutarlılığını kontrol ediyoruz. Renk paleti, ışık yönleri ve malzeme anlatımı üç başlık altında değerlendiriliyor. Eksik bulunan kısımlar için sorumlu kişiyi belirleyip kısa teslim tarihleri veriyoruz.",
+        "paragraph2": "Bu yöntem, sunum dosyalarının farklı kişiler tarafından hazırlanmış olsa bile aynı dili konuşmasını sağlıyor."
+      },
+      "archive": {
+        "heading": "Arşivleme ve paylaşım",
+        "paragraph1": "Oturum sonunda kullanılan tüm görsel ve dosyaları ortak sunucuda klasörleyerek saklıyoruz. Her klasörde tarih, oturum sorumlusu ve revizyon notlarının yer aldığı bir kapak belgesi bulunuyor.",
+        "paragraph2": "Düzenli arşiv tutmak, sonraki toplantılarda referans alabileceğimiz hazır içerikler oluşturuyor ve ekibin tekrar iş üretmesini engelliyor."
+      }
+    },
+    "backLink": "Tüm yazılara dön"
+  },
+  "careers": {
+    "intro": {
+      "eyebrow": "Kariyer",
+      "title": "Sunum Odaklı Mimarlığa Katılın",
+      "body": "Alpimimarlık, küçük ama disiplinli ekibiyle konsept sunumlarını, maket çekimlerini ve şantiye öncesi iletişimi yönetiyor. Galata'daki stüdyomuzda hazırladığımız görsel anlatılara katkı sunacak meraklı çalışma arkadaşları arıyoruz."
+    },
+    "values": {
+      "rhythm": {
+        "label": "Çalışma Düzeni",
+        "title": "Atölye Tempo",
+        "body": "Haftada dört gün stüdyoda, bir gün uzaktan ortak eskiz oturumları düzenliyoruz. Sunum dosyaları ekip içinde paylaşılıyor, revizyonlar hızla ilerliyor."
+      },
+      "mentoring": {
+        "label": "Mentorluk",
+        "title": "Beraber Öğrenme",
+        "body": "Yeni katılan ekip arkadaşları, stüdyo kurucu ortaklarıyla bire bir proje takip oturumlarına giriyor. Tüm sunum şablonlarını birlikte geliştiriyoruz."
+      },
+      "atmosphere": {
+        "label": "Ortam",
+        "title": "Sıcak Stüdyo",
+        "body": "Galata sokaklarındaki ritmi stüdyoya taşıyan samimi bir ekip var. Maket masası, ses sistemi ve fotoğraf köşesi her zaman açık."
+      }
+    },
+    "roles": {
+      "eyebrow": "Açık Pozisyonlar",
+      "title": "Güncel Aradığımız Roller",
+      "description": "Aşağıdaki roller için portfolyo, kısa niyet mektubu ve iletişim bilgilerinizi paylaşırsanız bir haftalık sürede geri dönüş yapıyoruz.",
+      "cta": "Başvuruyu Gönder",
+      "positions": {
+        "presentationArchitect": {
+          "title": "Sunum Mimarı",
+          "body": "Konsept toplantılarında kullanılacak plan, kesit ve atmosfer panolarını hazırlayacak; maket çekimlerini katalog diline taşıyacak bir ekip arkadaşı arıyoruz. Rhino, Enscape ve Adobe InDesign kullanımı bekleniyor.",
+          "bullets": {
+            "one": "• 2-4 yıl mimari sunum deneyimi",
+            "two": "• Detaylı Türkçe metin ve kısa İngilizce özet yazabilme",
+            "three": "• Şantiye öncesi toplantılara katılım"
+          }
+        },
+        "visualDesigner": {
+          "title": "Görsel İletişim Tasarımcısı",
+          "body": "Kampanya lansmanlarında kullanılacak posterler, sosyal medya düzenleri ve sunum kapaklarını birlikte tasarlayacağız. Tasarım dilimizi korurken yeni tipografi önerileri getirecek bir ekip arkadaşı arıyoruz.",
+          "bullets": {
+            "one": "• Adobe Illustrator ve Figma deneyimi",
+            "two": "• Mimarlık görselleriyle çalışmaya yatkınlık",
+            "three": "• Kısa süreli freelance iş birliklerine açık"
+          }
+        },
+        "studioIntern": {
+          "title": "Stüdyo Stajyeri",
+          "body": "Yaz döneminde stüdyomuzda eskiz ve maket süreçlerine destek verecek, toplantı öncesi sunum klasörlerini düzenleyecek bir stajyer arıyoruz. Okul projelerindeki anlatım dilinizi görmek isteriz.",
+          "bullets": {
+            "one": "• 3. veya 4. sınıf mimarlık öğrencisi",
+            "two": "• Haftada en az üç gün stüdyoda bulunabilme",
+            "three": "• Model yapımında hassasiyet"
+          }
+        }
+      }
+    },
+    "application": {
+      "eyebrow": "Başvuru",
+      "title": "Nasıl Başvurulur?",
+      "body1": "Portfolyonuzu PDF formatında, maksimum 15 sayfa olacak şekilde düzenleyin. Kısa niyet mektubunda Alpimimarlık ekibiyle nasıl bir sunum geliştirmek istediğinizi anlatın. Referans olabilecek eğitmen veya önceki ekip arkadaşlarının iletişim bilgilerini eklemeyi unutmayın.",
+      "body2": "Başvurular kariyer@alpimimarlik.com adresine gönderiliyor. Bir hafta içerisinde toplantı veya portfolyo geri bildirimi için iletişime geçiyoruz.",
+      "cta": "Başvuruyu Paylaş"
+    }
+  },
+  "contact": {
+    "hero": {
+      "eyebrow": "İletişim",
+      "title": "Bize Ulaşın",
+      "body": "Kampanya odaklı mimarlık sunumlarımız hakkında konuşmak veya sunum arşivimizi incelemek isterseniz, aşağıdaki formu doldurun. İlk kez sunum hazırlayan ekipler için hızlı başlangıç oturumu planlıyoruz."
+    },
+    "form": {
+      "nameLabel": "Ad Soyad",
+      "namePlaceholder": "Adınız Soyadınız",
+      "emailLabel": "E-posta",
+      "emailPlaceholder": "ornek@studio.com",
+      "topicLabel": "Sunum İlgisi",
+      "topicOptions": {
+        "conceptBook": "Konsept kitap hazırlığı",
+        "renderSession": "Render ve görselleştirme oturumu",
+        "launchSet": "Dijital lansman seti",
+        "other": "Diğer"
+      },
+      "messageLabel": "Mesajınız",
+      "messagePlaceholder": "Ekibinizin ihtiyacını kısaca anlatın...",
+      "submit": "Gönder"
+    },
+    "aside": {
+      "studio": {
+        "label": "Stüdyo",
+        "location": "Istanbul, Galata",
+        "hours": "Hafta içi 10:00 - 18:00 arası randevu ile görüşme sağlanır."
+      },
+      "phone": {
+        "label": "Telefon",
+        "number": "+90 212 222 33 44"
+      },
+      "email": {
+        "label": "E-posta",
+        "address": "iletisim@alpimimarlik.com"
+      },
+      "archive": {
+        "label": "Sunum Arşivi",
+        "body": "Sunum öncesi paylaşılacak örnek görseller için özel bir galeri bağlantısı oluşturuyoruz. Talep formunda belirtin."
+      }
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html class="dark" lang="en">
+<html class="dark" lang="tr">
 <head>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <title>AMA - Alper Morkoç Architecture</title>
+    <title data-i18n="meta.titles.home">Alpimimarlık — Ana Sayfa</title>
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
@@ -50,52 +50,108 @@
         .reveal {
             animation: reveal 0.6s ease forwards;
         }
+
+        .concept-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .concept-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
     </style>
 </head>
 <body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black px-8 py-5 text-white md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white" data-i18n="common.brand">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" data-i18n="common.langLabel" for="langSwitcher">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/60 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="langSwitcher"
+                >
+                    <option data-i18n="common.language.tr" value="tr">TR</option>
+                    <option data-i18n="common.language.en" value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span data-i18n="common.menuButton">Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
     <main>
-        <section class="relative h-screen min-h-[650px] overflow-hidden text-white">
+        <section class="relative min-h-[780px] md:min-h-[900px] lg:min-h-[1000px] overflow-hidden text-white">
             <div class="absolute inset-0">
                 <div class="flex h-full w-full transition-transform duration-700 ease-in-out" id="carousel">
                     <div
                         class="carousel-item relative h-full w-full"
-                        data-category="Residential"
-                        data-description="Revealing the first glimpses of life in a serene coastal retreat where refined lines meet the Aegean horizon."
-                        data-location="Bodrum, TR"
-                        data-title="Nef Reserve Gölköy"
+                        data-category="Kampanya Vitrini"
+                        data-description="Gün ışığıyla nefes alan çalışma adaları, yeni ofisimizin sakin ama üretken temposunu sahne ışığı altına taşıyor."
+                        data-location="Merkez Stüdyo"
+                        data-title="Gün Doğumu Stüdyo Kurgusu"
+                        data-i18n-data-category="index.hero.slide1.category"
+                        data-i18n-data-description="index.hero.slide1.description"
+                        data-i18n-data-location="index.hero.slide1.location"
+                        data-i18n-data-title="index.hero.slide1.title"
                     >
                         <img
-                            alt="Nef Reserve Gölköy"
+                            alt="Cam duvarlarla çevrili aydınlık çalışma alanı"
                             class="h-full w-full object-cover"
-                            src="https://lh3.googleusercontent.com/aida-public/AB6AXuBY3ViKq1aw3yXDhhfDzgn7d0Vnt9jkYwQLGkJo0WUnOSAcz06Acijs0rfUd0xb9zxwwedHo2UBB6vTEREgApkNX5S4pv1vRV9RH5B9nCgadZSPz8edx5Oegr7Vkl61cWtBT8vpoeYYONTO_1dQasguKJknaYBs5x-ksJA5c-Xwg-FAO92cpnoXersUR8s4cA3gg84RtdesgofL6GVefDsHtJABqFzz-Eiljg6sCLAXqvHOLTd-bZt5Avma1ITGxYiogtxhLn5cU3s"
+                            src="https://images.unsplash.com/photo-1497366216548-37526070297c?auto=format&fit=crop&w=1600&q=80"
                         />
                         <div class="absolute inset-0 bg-gradient-to-r from-black/80 via-black/30 to-black/40"></div>
                     </div>
                     <div
                         class="carousel-item relative h-full w-full"
-                        data-category="Cultural"
-                        data-description="A sculpted public space in Riyadh that folds desert light into a contemporary urban experience."
-                        data-location="Riyadh, SA"
-                        data-title="Al Sahra Pavilion"
+                        data-category="Mekân Lansmanı"
+                        data-description="Doğal taş ve yumuşak aydınlatma birlikteliği, giriş holünü markamızın sıcak tonlarıyla buluşturan davetkâr bir sahneye dönüştürüyor."
+                        data-location="Giriş Holü"
+                        data-title="Yumuşak Işıkta Karşılama"
+                        data-i18n-data-category="index.hero.slide2.category"
+                        data-i18n-data-description="index.hero.slide2.description"
+                        data-i18n-data-location="index.hero.slide2.location"
+                        data-i18n-data-title="index.hero.slide2.title"
                     >
                         <img
-                            alt="Architectural detail of a modern building"
+                            alt="Ahşap detaylara sahip sıcak karşılaşma alanı"
                             class="h-full w-full object-cover"
-                            src="https://lh3.googleusercontent.com/aida-public/AB6AXuDywh5KHJIrXp4s52K1q899PeRE9lFxVweHMW2m5xVN5GAmy9rXujubUdVBDEb-52DZCJp8ESyuMVD_iEpICFtvVL6QsGb93VmuZxZS2PJB6fJAIbiNy8gFLVVeLF4ljljtdkYfvQ4Zth5632bC7EwePczCSU-byb1tPIHSyUcXztEFgLEIO51I97KC8pNhm7AiIDRl0eeST75VN8H9S7ncLlFfgKAAeySs12gW0IO-bRgtDVQ4sq1_n5jqPeqOZDy0fEuyZiJHm0"
+                            src="https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1600&q=80"
                         />
                         <div class="absolute inset-0 bg-gradient-to-r from-black/80 via-black/40 to-black/20"></div>
                     </div>
                     <div
                         class="carousel-item relative h-full w-full"
-                        data-category="Hospitality"
-                        data-description="An immersive interior landscape that blurs the threshold between nature, art, and crafted comfort."
-                        data-location="Istanbul, TR"
-                        data-title="Aether Residence"
+                        data-category="Gece Senaryosu"
+                        data-description="Kentin ritmine eşlik eden cephe ışıkları, ofisimizin akşam saatlerindeki rafine duruşunu panoramaya taşıyor."
+                        data-location="Kent Silueti"
+                        data-title="Akşam Cephesi"
+                        data-i18n-data-category="index.hero.slide3.category"
+                        data-i18n-data-description="index.hero.slide3.description"
+                        data-i18n-data-location="index.hero.slide3.location"
+                        data-i18n-data-title="index.hero.slide3.title"
                     >
                         <img
-                            alt="Interior of a modern house"
+                            alt="Gece ışıklarıyla parlayan ofis cephesi"
                             class="h-full w-full object-cover"
-                            src="https://lh3.googleusercontent.com/aida-public/AB6AXuAGbCFIA5CK9Pt4bi0fEdIphWGRzysF0RACqcAQrhCRIPHNhljJIo6DXOsFA5HPMoO8zXERyza-Pl9_e2OnZ-xhgdR2DLkBdVZYKQhOU427ZgDH9NZowetlX5r8f0oCfikqMJkrSuabc9Pi1C7s9zIfz3eUbptgsAll8sluvlI2-86xYefKmDEughe06TuGjVz0RSjVQXHL9l_ze9uidcyYGPuDr_t-CPGqqwi2ZkM7eIn8BIcOvFtdYcURahWa7XoWGf4HO3kRaHY"
+                            src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80"
                         />
                         <div class="absolute inset-0 bg-gradient-to-r from-black/85 via-black/40 to-black/10"></div>
                     </div>
@@ -103,32 +159,14 @@
             </div>
             <div class="pointer-events-none absolute inset-0 bg-gradient-to-b from-black via-black/10 to-background-dark"></div>
 
-            <header class="absolute top-0 left-0 right-0 z-30 px-8 py-10 md:px-16">
-                <div class="flex items-center justify-between">
-                    <div class="text-sm font-display uppercase tracking-[0.6em] text-white/80">
-                        <span class="font-bold text-white">Alper Morkoç</span> Architecture
-                    </div>
-                    <nav class="hidden items-center space-x-10 text-xs uppercase tracking-[0.45em] text-white/70 md:flex">
-                        <a class="transition-opacity hover:opacity-60" href="#">Studio</a>
-                        <a class="transition-opacity hover:opacity-60" href="#">Projects</a>
-                        <a class="transition-opacity hover:opacity-60" href="#">Insights</a>
-                        <a class="transition-opacity hover:opacity-60" href="#">Contact</a>
-                    </nav>
-                    <button class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60">
-                        <span class="material-icons text-base">search</span>
-                        <span>Search</span>
-                    </button>
-                </div>
-            </header>
-
             <div class="relative z-20 flex h-full flex-col justify-end px-8 pb-24 md:px-20">
-                <div class="pointer-events-auto max-w-3xl space-y-6">
-                    <p class="text-xs uppercase tracking-[0.55em] text-white/60" id="slide-category">Residential</p>
-                    <h1 class="text-4xl font-display font-light leading-[1.1] text-white transition-all duration-500 md:text-6xl" id="slide-title">
-                        Nef Reserve Gölköy
+                <div class="pointer-events-auto max-w-3xl">
+                    <p class="text-xs uppercase tracking-[0.55em] text-white/60" data-i18n="index.hero.slide1.category" id="slide-category">Kampanya Vitrini</p>
+                    <h1 class="mt-4 text-4xl font-display font-light leading-tight text-white transition-all duration-500 md:text-6xl md:leading-[1.1]" data-i18n="index.hero.slide1.title" id="slide-title">
+                        Gün Doğumu Stüdyo Kurgusu
                     </h1>
-                    <p class="text-sm text-white/70 md:text-base" id="slide-description">
-                        Revealing the first glimpses of life in a serene coastal retreat where refined lines meet the Aegean horizon.
+                    <p class="mt-5 text-sm text-white/70 md:mt-6 md:text-base" data-i18n="index.hero.slide1.description" id="slide-description">
+                        Gün ışığıyla nefes alan çalışma adaları, yeni ofisimizin sakin ama üretken temposunu sahne ışığı altına taşıyor.
                     </p>
                 </div>
                 <div class="pointer-events-auto mt-12 flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
@@ -137,7 +175,7 @@
                         <span class="font-display text-sm text-white" id="slide-index">01</span>
                         <span class="text-white/40">/</span>
                         <span class="font-display text-sm text-white/70" id="slide-total">03</span>
-                        <span class="text-white/50" id="slide-location">Bodrum, TR</span>
+                        <span class="text-white/50" data-i18n="index.hero.slide1.location" id="slide-location">Merkez Stüdyo</span>
                     </div>
                     <div class="flex items-center gap-6">
                         <div class="relative h-0.5 w-32 overflow-hidden bg-white/25">
@@ -165,110 +203,110 @@
 
             <div class="pointer-events-none absolute bottom-10 left-8 flex items-center gap-5 text-[0.55rem] uppercase tracking-[0.6em] text-white/40 md:left-20">
                 <span class="h-8 w-px bg-white/25"></span>
-                <span>Scroll to explore</span>
+                <span data-i18n="index.hero.scrollHint">Scroll to explore</span>
             </div>
         </section>
 
         <section class="bg-background-dark px-8 py-20 text-primary md:px-20">
             <div class="flex flex-col gap-12 md:flex-row md:items-end md:justify-between">
                 <div>
-                    <p class="text-xs uppercase tracking-[0.55em] text-accent">Featured Works</p>
-                    <h2 class="mt-4 max-w-2xl text-3xl font-display text-white md:text-5xl">Stories from Alper Morkoç Architecture</h2>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="index.vision.eyebrow">Stüdyo Vizyonu</p>
+                    <h2 class="mt-4 max-w-2xl text-3xl font-display text-white md:text-5xl" data-i18n="index.vision.title">Alpimimarlık'ın Sunum Yaklaşımı</h2>
                 </div>
-                <div class="max-w-xl text-sm text-gray-400">
-                    <p>
-                        A curated selection of places, people, and crafted experiences that define the studio's multidimensional practice across the globe.
+                <div class="max-w-2xl space-y-5 text-sm text-gray-400">
+                    <p data-i18n="index.vision.body1">
+                        Projelerimizi yalın anlatımlı sunumlar ve detaylı maket çalışmaları eşliğinde paylaşıyoruz. Hazırladığımız görsel sunumlar, ofisimizin ölçekli düşünme becerisini ve samimi iletişim dilini kısa tanıtım metinleriyle birlikte ortaya koymayı hedefliyor.
+                    </p>
+                    <p data-i18n="index.vision.body2">
+                        Her sunum klasöründe, giriş sahnesinden gece cephe kurgusuna kadar uzanan atmosfer anlatıları yer alıyor. Hazırlık sürecinde paylaştığımız eskizler ve maket fotoğrafları, anlatının tonunu koruyarak ekiplerin tanıtım adımlarını hızlandırıyor.
                     </p>
                 </div>
-            </div>
-            <div class="mt-16 grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
-                <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
-                    <img
-                        alt="Design team in conversation"
-                        class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                        src="https://images.unsplash.com/photo-1529429617124-aee575b5dbb3?auto=format&fit=crop&w=1100&q=80"
-                    />
-                    <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
-                    <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Studio Life</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Inside the Istanbul Atelier</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Collaborative spaces that bring craft, technology, and dialogue together.</p>
-                    </div>
-                </article>
-                <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
-                    <img
-                        alt="Modern cultural pavilion"
-                        class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                        src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1100&q=80"
-                    />
-                    <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
-                    <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Perspective</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Resilient Cultural Landscapes</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Design strategies that respond to climate while celebrating local narratives.</p>
-                    </div>
-                </article>
-                <article class="group relative overflow-hidden rounded-sm border border-white/5 bg-black/30">
-                    <img
-                        alt="High-rise skyline"
-                        class="h-64 w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                        src="https://images.unsplash.com/photo-1487956382158-bb926046304a?auto=format&fit=crop&w=1100&q=80"
-                    />
-                    <div class="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent"></div>
-                    <div class="absolute bottom-0 p-6">
-                        <p class="text-[0.55rem] uppercase tracking-[0.6em] text-white/50">Global Practice</p>
-                        <h3 class="mt-3 text-2xl font-display text-white transition-colors duration-300 group-hover:text-primary">Elevating Urban Skylines</h3>
-                        <p class="mt-2 max-w-xs text-sm text-white/70">Hybrid towers that balance hospitality, culture, and public experience.</p>
-                    </div>
-                </article>
             </div>
         </section>
     </main>
 
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="common.brand" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white" data-i18n="common.menuPanel.title">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" data-i18n="common.nav.home" href="index.html">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" data-i18n="common.nav.studio" href="studio.html">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" data-i18n="common.nav.services" href="services.html">Services</a>
+                <a class="block transition-opacity hover:opacity-60" data-i18n="common.nav.insights" href="insights.html">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" data-i18n="common.nav.careers" href="kariyer.html">Kariyer</a>
+                <a class="block transition-opacity hover:opacity-60" data-i18n="common.nav.contact" href="contact.html">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40" data-i18n="common.menuPanel.contactHeading">İletişim</p>
+                <p data-i18n="common.menuPanel.contactBody">Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span data-i18n="common.menuPanel.email">iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
     <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
         <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
             <div>
-                <h3 class="text-xl font-display font-bold tracking-tight text-white">Alper Morkoç Architecture</h3>
-                <p class="mt-3 text-sm text-gray-400">
+                <h3 class="text-xl font-display font-bold tracking-tight text-white" data-i18n="common.footer.title">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400" data-i18n="common.footer.tagline">
                     Pioneering architectural narratives shaped by context, craft, and human experience.
                 </p>
             </div>
             <div>
-                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Navigate</h3>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.navigate">Navigate</h3>
                 <ul class="mt-4 space-y-3 text-sm text-gray-400">
-                    <li><a class="transition-colors hover:text-white" href="#">Istanbul</a></li>
-                    <li><a class="transition-colors hover:text-white" href="#">London</a></li>
-                    <li><a class="transition-colors hover:text-white" href="#">New York</a></li>
+                    <li><a class="transition-colors hover:text-white" data-i18n="common.nav.home" href="index.html">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" data-i18n="common.nav.studio" href="studio.html">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" data-i18n="common.nav.services" href="services.html">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" data-i18n="common.nav.insights" href="insights.html">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" data-i18n="common.nav.careers" href="kariyer.html">Kariyer</a></li>
+                    <li><a class="transition-colors hover:text-white" data-i18n="common.nav.contact" href="contact.html">Contact</a></li>
                 </ul>
             </div>
             <div>
-                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Connect</h3>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.connect">Connect</h3>
                 <ul class="mt-4 space-y-3 text-sm text-gray-400">
-                    <li><a class="transition-colors hover:text-white" href="#">Instagram</a></li>
-                    <li><a class="transition-colors hover:text-white" href="#">LinkedIn</a></li>
-                    <li><a class="transition-colors hover:text-white" href="#">Behance</a></li>
-                    <li><a class="transition-colors hover:text-white" href="#">YouTube</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.instagram">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.linkedin">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.behance">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.youtube">YouTube</a></li>
                 </ul>
             </div>
             <div>
-                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70">Newsletter</h3>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.newsletter">Newsletter</h3>
                 <form class="mt-4 space-y-3">
                     <input
                         class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
-                        placeholder="Enter your email"
+                        data-i18n-placeholder="common.footer.newsletterPlaceholder" placeholder="Enter your email"
                         type="email"
                     />
-                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit">
-                        Join
-                    </button>
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" data-i18n="common.footer.newsletterButton" type="submit">Join</button>
                 </form>
             </div>
         </div>
         <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
-            <p>© 2024 Alper Morkoç Architecture. All Rights Reserved.</p>
+            <p data-i18n="common.footer.copyright">© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
         </div>
     </footer>
 
+    <script src="assets/js/i18n.js"></script>
     <script>
         const carousel = document.getElementById('carousel');
         const prevBtn = document.getElementById('prev-btn');
@@ -281,6 +319,9 @@
         const slideLocation = document.getElementById('slide-location');
         const slideIndex = document.getElementById('slide-index');
         const slideTotal = document.getElementById('slide-total');
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
         const totalItems = items.length;
 
         let currentIndex = 0;
@@ -350,9 +391,68 @@
             startAutoplay();
         });
 
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => {
+                menuPanel.classList.add('opacity-100');
+            });
+            stopAutoplay();
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => {
+                menuPanel.classList.add('hidden');
+            }, 180);
+            startAutoplay();
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+        document.addEventListener('i18n:change', () => {
+            updateTextualContent();
+        });
+
         slideTotal.textContent = padNumber(totalItems);
-        goToSlide(0);
-        startAutoplay();
+
+        const initCarousel = () => {
+            goToSlide(0);
+            startAutoplay();
+        };
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initCarousel, { once: true });
+        } else {
+            initCarousel();
+        }
     </script>
 </body>
 </html>

--- a/insight-konsept-oturumlari.html
+++ b/insight-konsept-oturumlari.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title data-i18n="meta.titles.insightSessions">Takım İçi Konsept Oturumları — Alpimimarlık Notları</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black px-8 py-5 text-white md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white" data-i18n="common.brand">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" data-i18n="common.langLabel" for="langSwitcher">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="langSwitcher"
+                >
+                    <option data-i18n="common.language.tr" value="tr">TR</option>
+                    <option data-i18n="common.language.en" value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span data-i18n="common.menuButton">Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="mx-auto max-w-4xl space-y-12">
+            <div class="space-y-6">
+                <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="insightSessions.hero.label">Atölye Özeti</p>
+                <h1 class="text-4xl font-display text-white md:text-5xl" data-i18n="insightSessions.hero.title">Takım İçi Konsept Oturumları</h1>
+                <p class="text-sm uppercase tracking-[0.35em] text-white/50" data-i18n="insightSessions.hero.meta">Yayın Tarihi — 26 Şubat 2024</p>
+                <div
+                    aria-label="Takım içi sunum oturumu için ışık denemesi"
+                    class="ai-visual h-60 w-full"
+                    role="img"
+                    style="background-image: radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 50%), radial-gradient(circle at 78% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #141522, #1c1f31 58%, #322544);"
+                ></div>
+                <p class="text-lg text-white/80" data-i18n="insightSessions.hero.intro">
+                    Haftalık olarak yaptığımız konsept oturumları, sunum dosyalarımızın tutarlı ve hızlı bir şekilde gelişmesini sağlıyor.
+                    Bu yazı, oturumların nasıl planlandığını, hangi çıktıları beklediğimizi ve ekip içinde görev paylaşımını nasıl yaptığımızı açıklıyor.
+                </p>
+            </div>
+
+            <article class="prose prose-invert max-w-none">
+                <h2 data-i18n="insightSessions.sections.schedule.heading">Toplantı düzeni</h2>
+                <p data-i18n="insightSessions.sections.schedule.paragraph1">
+                    Her oturum, 45 dakikalık zaman bloklarından oluşuyor. İlk bölümde bir kişi güncel sunum taslağını paylaşıyor.
+                    Diğer ekip üyeleri sorularını not alarak sadece dinliyor.
+                    Sunum tamamlandıktan sonra soruları sırayla yanıtlıyor ve gerekli revizyonları birlikte işaretliyoruz.
+                </p>
+                <p data-i18n="insightSessions.sections.schedule.paragraph2">
+                    Oturumda alınan notlar, toplantı sonrası 24 saat içinde paylaşılan kısa bir özetle dokümante ediliyor.
+                    Böylece herkes yapılacak işleri ve teslim tarihlerini net olarak görüyor.
+                </p>
+
+                <h2 data-i18n="insightSessions.sections.checklist.heading">Görsel kontrol listesi</h2>
+                <p data-i18n="insightSessions.sections.checklist.paragraph1">
+                    Her oturumun ikinci bölümünde, görsellerin tutarlılığını kontrol ediyoruz.
+                    Renk paleti, ışık yönleri ve malzeme anlatımı üç başlık altında değerlendiriliyor.
+                    Eksik bulunan kısımlar için sorumlu kişiyi belirleyip kısa teslim tarihleri veriyoruz.
+                </p>
+                <p data-i18n="insightSessions.sections.checklist.paragraph2">
+                    Bu yöntem, sunum dosyalarının farklı kişiler tarafından hazırlanmış olsa bile aynı dili konuşmasını sağlıyor.
+                </p>
+
+                <h2 data-i18n="insightSessions.sections.archive.heading">Arşivleme ve paylaşım</h2>
+                <p data-i18n="insightSessions.sections.archive.paragraph1">
+                    Oturum sonunda kullanılan tüm görsel ve dosyaları ortak sunucuda klasörleyerek saklıyoruz.
+                    Her klasörde tarih, oturum sorumlusu ve revizyon notlarının yer aldığı bir kapak belgesi bulunuyor.
+                </p>
+                <p data-i18n="insightSessions.sections.archive.paragraph2">
+                    Düzenli arşiv tutmak, sonraki toplantılarda referans alabileceğimiz hazır içerikler oluşturuyor ve ekibin tekrar iş üretmesini engelliyor.
+                </p>
+            </article>
+
+            <div class="border-t border-white/10 pt-10">
+                <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" data-i18n="insightSessions.backLink" href="insights.html">
+                    <span class="material-icons mr-2 text-sm">west</span>
+                    Tüm yazılara dön
+                </a>
+            </div>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="common.brand" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white" data-i18n="common.menuPanel.title">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html" data-i18n="common.nav.home">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html" data-i18n="common.nav.studio">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html" data-i18n="common.nav.services">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html" data-i18n="common.nav.insights">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html" data-i18n="common.nav.contact">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40" data-i18n="common.menuPanel.contactHeading">İletişim</p>
+                <p data-i18n="common.menuPanel.contactBody">Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white" data-i18n="common.footer.title">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400" data-i18n="common.footer.tagline">                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.navigate">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html" data-i18n="common.nav.home">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html" data-i18n="common.nav.studio">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html" data-i18n="common.nav.services">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html" data-i18n="common.nav.insights">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html" data-i18n="common.nav.contact">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.connect">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.instagram">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.linkedin">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.behance">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.youtube">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.newsletter">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        data-i18n-placeholder="common.footer.newsletterPlaceholder" placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" data-i18n="common.footer.newsletterButton" type="submit">Join</button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p data-i18n="common.footer.copyright">© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/i18n.js"></script>
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+    </script>
+</body>
+</html>

--- a/insight-lobi-ilk-izlenim.html
+++ b/insight-lobi-ilk-izlenim.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title data-i18n="meta.titles.insightLobby">Lobi Sunumunda İlk İzlenim — Alpimimarlık Notları</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black px-8 py-5 text-white md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white" data-i18n="common.brand">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" data-i18n="common.langLabel" for="langSwitcher">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="langSwitcher"
+                >
+                    <option data-i18n="common.language.tr" value="tr">TR</option>
+                    <option data-i18n="common.language.en" value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span data-i18n="common.menuButton">Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="mx-auto max-w-4xl space-y-12">
+            <div class="space-y-6">
+                <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="insightLobby.hero.label">Saha Notu</p>
+                <h1 class="text-4xl font-display text-white md:text-5xl" data-i18n="insightLobby.hero.title">Lobi Sunumunda İlk İzlenim</h1>
+                <p class="text-sm uppercase tracking-[0.35em] text-white/50" data-i18n="insightLobby.hero.meta">Yayın Tarihi — 18 Ocak 2024</p>
+                <div
+                    aria-label="Lobi sunumu için hazırlanan ışık ve renk kurgusu"
+                    class="ai-visual h-60 w-full"
+                    role="img"
+                    style="background-image: radial-gradient(circle at 22% 30%, rgba(255, 206, 165, 0.8) 0%, rgba(255, 206, 165, 0) 55%), radial-gradient(circle at 78% 65%, rgba(255, 126, 126, 0.45) 0%, rgba(255, 126, 126, 0) 50%), linear-gradient(150deg, #1e1f2d, #101019 58%, #2e2439);"
+                ></div>
+                <p class="text-lg text-white/80" data-i18n="insightLobby.hero.intro">
+                    Lobi sahnesi, küçük bir ofisin kimliğini ilk dakikada aktarması için kullandığımız en güçlü araç. Bu yazı,
+                    hazırladığımız sunum dosyalarında nasıl bir hikâye kurduğumuzu, mekânı tanımlarken hangi öncelikleri göz önünde bulundurduğumuzu anlatıyor.
+                </p>
+            </div>
+
+            <article class="prose prose-invert max-w-none">
+                <h2 data-i18n="insightLobby.sections.route.heading">Ziyaretçi rotasını netleştirmek</h2>
+                <p data-i18n="insightLobby.sections.route.paragraph1">
+                    İlk sunumda kullandığımız plan şemasında, ziyaretçinin girişten toplantı alanına kadar izleyeceği adımları kısaca tarif ediyoruz.
+                    Kapı, danışma ve bekleme alanları arasında net bir rota oluşturmak, müşterinin zihninde mekânın akışını canlandırıyor.
+                    Planın yanında, zemin kaplaması ve yönlendirme elemanları için seçtiğimiz malzemeleri belirtiyoruz.
+                </p>
+                <p data-i18n="insightLobby.sections.route.paragraph2">
+                    Bu bölümde gereksiz detaylardan kaçınarak üç ana mesaj iletiyoruz: girişten itibaren hissedilen atmosfer, bekleme alanındaki oturma düzeni ve toplantı odasına geçişte ışığın nasıl değiştiği.
+                    Bu üç başlık, lobiye ilişkin ilk soruları yanıtlıyor ve toplantının ilerleyen dakikalarına sağlam bir zemin hazırlıyor.
+                </p>
+
+                <h2 data-i18n="insightLobby.sections.light.heading">Işık ve malzeme dengesi</h2>
+                <p data-i18n="insightLobby.sections.light.paragraph1">
+                    Lobi anlatımında ışık, mekânı tanıtan ilk görsel ipucu. Gündüz ve akşam senaryoları için iki ayrı aydınlatma şeması hazırlıyoruz.
+                    Gündüz senaryosunda doğal ışığın yoğunluğunu gösteren kısa bir kesit, akşam senaryosunda ise sıcaklığı ayarlanabilir armatürlerin mekâna yayılışını vurgulayan bir kolaj kullanıyoruz.
+                </p>
+                <p data-i18n="insightLobby.sections.light.paragraph2">
+                    Malzeme paleti seçimimiz, ışığın anlatmak istediği duyguyu destekliyor. Mat yüzeyler ışığı yumuşatırken, bakır veya pirinç detaylar odağı güçlendiriyor.
+                    Paleti üç ana renkle sınırlamak, anlatımın sade ve anlaşılır kalmasını sağlıyor.
+                </p>
+
+                <h2 data-i18n="insightLobby.sections.structure.heading">Sunum planını yapılandırmak</h2>
+                <p data-i18n="insightLobby.sections.structure.paragraph1">
+                    Sunum dosyasını hazırlarken lobiyi tek seferde anlatmak yerine kısa adımlara bölüyoruz.
+                    İlk sayfa mekânın duygusunu veren geniş açı, ikinci sayfa kullanıcı deneyimi hikâyesi ve üçüncü sayfa malzeme ile aydınlatma tablosu.
+                    Bu yapı sayesinde toplantı sırasında her bölüm için kısa, net bir açıklama yapabiliyoruz.
+                </p>
+                <p data-i18n="insightLobby.sections.structure.paragraph2">
+                    Sunumun sonunda, lobinin bitmiş halini temsil eden bir görseli, kontrol listesi ile birlikte paylaşarak görüşmeyi tamamlıyoruz.
+                    Liste; aydınlatma kurulumu, yönlendirme grafikleri ve mobilya yerleşiminden oluşuyor.
+                    Böylece görüşmeden çıkan herkes, yapılacak işlerin sırasını ve beklenen atmosferi aynı şekilde hayal ediyor.
+                </p>
+            </article>
+
+            <div class="border-t border-white/10 pt-10">
+                <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" data-i18n="insightLobby.backLink" href="insights.html">
+                    <span class="material-icons mr-2 text-sm">west</span>
+                    Tüm yazılara dön
+                </a>
+            </div>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="common.brand" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white" data-i18n="common.menuPanel.title">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html" data-i18n="common.nav.home">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html" data-i18n="common.nav.studio">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html" data-i18n="common.nav.services">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html" data-i18n="common.nav.insights">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html" data-i18n="common.nav.contact">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40" data-i18n="common.menuPanel.contactHeading">İletişim</p>
+                <p data-i18n="common.menuPanel.contactBody">Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white" data-i18n="common.footer.title">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400" data-i18n="common.footer.tagline">                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.navigate">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html" data-i18n="common.nav.home">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html" data-i18n="common.nav.studio">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html" data-i18n="common.nav.services">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html" data-i18n="common.nav.insights">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html" data-i18n="common.nav.contact">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.connect">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.instagram">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.linkedin">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.behance">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.youtube">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.newsletter">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        data-i18n-placeholder="common.footer.newsletterPlaceholder" placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit" data-i18n="common.footer.newsletterButton">Join</button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p data-i18n="common.footer.copyright">© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/i18n.js"></script>
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+    </script>
+</body>
+</html>

--- a/insight-metinsiz-sahne.html
+++ b/insight-metinsiz-sahne.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title data-i18n="meta.titles.insightScene">Metinsiz Sahne Nasıl Anlatılır? — Alpimimarlık Notları</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black px-8 py-5 text-white md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white" data-i18n="common.brand">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" data-i18n="common.langLabel" for="langSwitcher">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="langSwitcher"
+                >
+                    <option data-i18n="common.language.tr" value="tr">TR</option>
+                    <option data-i18n="common.language.en" value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span data-i18n="common.menuButton">Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="mx-auto max-w-4xl space-y-12">
+            <div class="space-y-6">
+                <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="insightScene.hero.label">Rehber</p>
+                <h1 class="text-4xl font-display text-white md:text-5xl" data-i18n="insightScene.hero.title">Metinsiz Sahne Nasıl Anlatılır?</h1>
+                <p class="text-sm uppercase tracking-[0.35em] text-white/50" data-i18n="insightScene.hero.meta">Yayın Tarihi — 4 Şubat 2024</p>
+                <div
+                    aria-label="Metinsiz sahne anlatımı için kolaj"
+                    class="ai-visual h-60 w-full"
+                    role="img"
+                    style="background-image: radial-gradient(circle at 70% 30%, rgba(160, 214, 255, 0.7) 0%, rgba(160, 214, 255, 0) 55%), radial-gradient(circle at 18% 70%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(160deg, #1a2334, #0f131d 60%, #2a3245);"
+                ></div>
+                <p class="text-lg text-white/80" data-i18n="insightScene.hero.intro">
+                    Sunum dosyalarında boş kalan sayfaları, metin kullanmadan da etkili bir şekilde kurgulamak mümkün.
+                    Bu rehberde kullandığımız yöntemleri, hikâyeyi kelimeler yerine görsel ipuçlarıyla nasıl güçlendirdiğimizi özetliyoruz.
+                </p>
+            </div>
+
+            <article class="prose prose-invert max-w-none">
+                <h2 data-i18n="insightScene.sections.atmosphere.heading">Atmosferi kelimeler olmadan kurmak</h2>
+                <p data-i18n="insightScene.sections.atmosphere.paragraph1">
+                    Metinsiz sahne anlatımına başlamadan önce, mekânın hangi duyguya odaklandığını belirliyoruz.
+                    Işık yönü, renk paleti ve kullanılan malzemeler bu duygunun temelini oluşturuyor.
+                    Geniş açılı bir görsel yerine, belirli bir noktayı tarif eden üç kare kullanmak, izleyicinin bakışını yönlendiriyor.
+                </p>
+                <p data-i18n="insightScene.sections.atmosphere.paragraph2">
+                    Her karede bir ana unsur seçiyoruz: zemin dokusu, oturma düzeni veya cepheye sızan ışık gibi.
+                    Böylece izleyici, sahnenin bütününü kelime okumadan da kavrıyor.
+                </p>
+
+                <h2 data-i18n="insightScene.sections.story.heading">Kullanıcı hikâyesi oluşturmak</h2>
+                <p data-i18n="insightScene.sections.story.paragraph1">
+                    Metin yerine kısa bir hikâye kurgulamak için zaman çizelgesi yaklaşımı kullanıyoruz.
+                    Sabah, gün ortası ve akşam senaryolarını üç karede göstererek, mekânın gün boyunca nasıl yaşadığını aktarıyoruz.
+                </p>
+                <p data-i18n="insightScene.sections.story.paragraph2">
+                    Her senaryoda mekânı kullanan kişinin ihtiyacına odaklanan küçük ikonlar veya notlar eklemek, anlatımı destekliyor.
+                    Bunu yaparken tasarımın yalın kalmasına dikkat ediyoruz; her karede tek bir vurgu yeterli oluyor.
+                </p>
+
+                <h2 data-i18n="insightScene.sections.collage.heading">Kolaj ile son kareyi tamamlamak</h2>
+                <p data-i18n="insightScene.sections.collage.paragraph1">
+                    Sahnenin finalini, plan veya kesit üzerine oturttuğumuz kolajla tamamlıyoruz.
+                    Bu kolajda ışık yönlerini, mobilya yerleşimini ve renk yoğunluğunu göstermek için ince çizgiler ve kısa etiketler kullanıyoruz.
+                </p>
+                <p data-i18n="insightScene.sections.collage.paragraph2">
+                    Görsel anlatım, toplantı sırasında hızlı geri bildirim alınmasını sağlıyor.
+                    Metin eklemeye gerek kalmadan, sahnenin hangi noktalarının geliştirileceği netleşiyor.
+                </p>
+            </article>
+
+            <div class="border-t border-white/10 pt-10">
+                <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" data-i18n="insightScene.backLink" href="insights.html">
+                    <span class="material-icons mr-2 text-sm">west</span>
+                    Tüm yazılara dön
+                </a>
+            </div>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="common.brand" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white" data-i18n="common.menuPanel.title">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html" data-i18n="common.nav.home">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html" data-i18n="common.nav.studio">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html" data-i18n="common.nav.services">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html" data-i18n="common.nav.insights">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html" data-i18n="common.nav.contact">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40" data-i18n="common.menuPanel.contactHeading">İletişim</p>
+                <p data-i18n="common.menuPanel.contactBody">Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white" data-i18n="common.footer.title">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400" data-i18n="common.footer.tagline">                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.navigate">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html" data-i18n="common.nav.home">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html" data-i18n="common.nav.studio">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html" data-i18n="common.nav.services">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html" data-i18n="common.nav.insights">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html" data-i18n="common.nav.contact">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.connect">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.instagram">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.linkedin">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.behance">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.youtube">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.newsletter">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        data-i18n-placeholder="common.footer.newsletterPlaceholder" placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" data-i18n="common.footer.newsletterButton" type="submit">Join</button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p data-i18n="common.footer.copyright">© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/i18n.js"></script>
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+    </script>
+</body>
+</html>

--- a/insights.html
+++ b/insights.html
@@ -1,0 +1,272 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title data-i18n="meta.titles.insights">Insights — Alpimimarlık</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .ai-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .ai-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black px-8 py-5 text-white md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white" data-i18n="common.brand">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" data-i18n="common.langLabel" for="langSwitcher">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="langSwitcher"
+                >
+                    <option data-i18n="common.language.tr" value="tr">TR</option>
+                    <option data-i18n="common.language.en" value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span data-i18n="common.menuButton">Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="max-w-5xl space-y-12">
+            <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="insights.hero.eyebrow">Görüşler &amp; Notlar</p>
+            <h1 class="text-4xl font-display text-white md:text-5xl" data-i18n="insights.hero.title">Alpimimarlık Not Defteri</h1>
+            <p class="text-base text-white/70" data-i18n="insights.hero.body">
+                Müşterilerle paylaşılacak dosyaları hazırlarken kullandığımız yöntemleri burada toparlıyoruz.
+                Sunum akışı, görsel seçimleri ve küçük ekibimizin çalışma biçimi hakkında notlar içeren kısa makaleler paylaşıyoruz.
+            </p>
+            <div class="space-y-8">
+                <article class="space-y-3 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Lobi sahnesi için hazırlanan renk denemesi"
+                        class="ai-visual h-32 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 22% 30%, rgba(255, 206, 165, 0.8) 0%, rgba(255, 206, 165, 0) 55%), radial-gradient(circle at 78% 65%, rgba(255, 126, 126, 0.45) 0%, rgba(255, 126, 126, 0) 50%), linear-gradient(150deg, #1e1f2d, #101019 58%, #2e2439);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="insights.articles.lobby.label">Saha Notu</p>
+                    <h2 class="text-2xl font-display text-white" data-i18n="insights.articles.lobby.title">Lobi Sunumunda İlk İzlenim</h2>
+                    <p class="text-sm text-white/70" data-i18n="insights.articles.lobby.excerpt">
+                        İlk görüşmede paylaşılan lobi sahnesi, ziyaretçilerin mekânın atmosferini hızla anlamasını sağlıyor. Bizim için çalışan üç temel dokunuşu ve örnek sunum planını anlattık.
+                    </p>
+                    <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" data-i18n="insights.articles.lobby.link" href="insight-lobi-ilk-izlenim.html">
+                        Devamını Oku
+                        <span class="material-icons ml-2 text-sm">east</span>
+                    </a>
+                </article>
+                <article class="space-y-3 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Metinsiz sahne anlatımı için kolaj"
+                        class="ai-visual h-32 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 70% 30%, rgba(160, 214, 255, 0.7) 0%, rgba(160, 214, 255, 0) 55%), radial-gradient(circle at 18% 70%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(160deg, #1a2334, #0f131d 60%, #2a3245);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="insights.articles.scene.label">Rehber</p>
+                    <h2 class="text-2xl font-display text-white" data-i18n="insights.articles.scene.title">Metinsiz Sahne Nasıl Anlatılır?</h2>
+                    <p class="text-sm text-white/70" data-i18n="insights.articles.scene.excerpt">
+                        Görsel olmayan bölümler için kullandığımız üç adımlı strateji: atmosferi kelimelerle kurmak, kullanıcı hikâyesi yazmak ve son kareyi destekleyecek bir kolajla tamamlamak.
+                    </p>
+                    <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" data-i18n="insights.articles.scene.link" href="insight-metinsiz-sahne.html">
+                        Devamını Oku
+                        <span class="material-icons ml-2 text-sm">east</span>
+                    </a>
+                </article>
+                <article class="space-y-3 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Takım içi sunum oturumu için ışık denemesi"
+                        class="ai-visual h-32 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 50%), radial-gradient(circle at 78% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #141522, #1c1f31 58%, #322544);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="insights.articles.sessions.label">Atölye Özeti</p>
+                    <h2 class="text-2xl font-display text-white" data-i18n="insights.articles.sessions.title">Takım İçi Konsept Oturumları</h2>
+                    <p class="text-sm text-white/70" data-i18n="insights.articles.sessions.excerpt">
+                        Haftalık oturumlarımızda kullandığımız sahne tariflerini, ışık önerilerini ve renk paleti kombinlerini örnek dosyalarla birlikte derledik.
+                    </p>
+                    <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" data-i18n="insights.articles.sessions.link" href="insight-konsept-oturumlari.html">
+                        Devamını Oku
+                        <span class="material-icons ml-2 text-sm">east</span>
+                    </a>
+                </article>
+            </div>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="common.brand" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white" data-i18n="common.menuPanel.title">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html" data-i18n="common.nav.home">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html" data-i18n="common.nav.studio">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html" data-i18n="common.nav.services">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html" data-i18n="common.nav.insights">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html" data-i18n="common.nav.contact">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40" data-i18n="common.menuPanel.contactHeading">İletişim</p>
+                <p data-i18n="common.menuPanel.contactBody">Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white" data-i18n="common.footer.title">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400" data-i18n="common.footer.tagline">                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.navigate">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html" data-i18n="common.nav.home">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html" data-i18n="common.nav.studio">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html" data-i18n="common.nav.services">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html" data-i18n="common.nav.insights">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html" data-i18n="common.nav.contact">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.connect">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.instagram">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.linkedin">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.behance">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.youtube">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.newsletter">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        data-i18n-placeholder="common.footer.newsletterPlaceholder" placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit" data-i18n="common.footer.newsletterButton">Join</button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p data-i18n="common.footer.copyright">© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/i18n.js"></script>
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+    </script>
+</body>
+</html>

--- a/kariyer.html
+++ b/kariyer.html
@@ -1,0 +1,360 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title data-i18n="meta.titles.careers">Kariyer — Alpimimarlık</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .concept-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .concept-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black px-8 py-5 text-white md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white" data-i18n="common.brand">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" data-i18n="common.langLabel" for="langSwitcher">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="langSwitcher"
+                >
+                    <option data-i18n="common.language.tr" value="tr">TR</option>
+                    <option data-i18n="common.language.en" value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span data-i18n="common.menuButton">Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="mx-auto max-w-5xl space-y-16">
+            <section class="space-y-8">
+                <div class="grid gap-8 md:grid-cols-[1.5fr,1fr] md:items-end">
+                    <div class="space-y-6">
+                        <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="careers.intro.eyebrow">Kariyer</p>
+                        <h1 class="text-4xl font-display text-white md:text-5xl" data-i18n="careers.intro.title">Sunum Odaklı Mimarlığa Katılın</h1>
+                        <p class="text-base text-white/70" data-i18n="careers.intro.body">
+                            Alpimimarlık, küçük ama disiplinli ekibiyle konsept sunumlarını, maket çekimlerini ve şantiye öncesi iletişimi yönetiyor.
+                            Galata'daki stüdyomuzda hazırladığımız görsel anlatılara katkı sunacak meraklı çalışma arkadaşları arıyoruz.
+                        </p>
+                    </div>
+                    <div
+                        aria-label="Stüdyo çalışma masasını anlatan konsept görsel"
+                        class="concept-visual h-52 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 24% 30%, rgba(255, 208, 158, 0.75) 0%, rgba(255, 208, 158, 0) 55%), radial-gradient(circle at 78% 68%, rgba(164, 214, 255, 0.6) 0%, rgba(164, 214, 255, 0) 48%), linear-gradient(150deg, #1a1c28, #0f1119 62%, #2e253b));"
+                    ></div>
+                </div>
+                <div class="grid gap-10 md:grid-cols-3">
+                    <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                        <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="careers.values.rhythm.label">Çalışma Düzeni</p>
+                        <h2 class="text-xl font-display text-white" data-i18n="careers.values.rhythm.title">Atölye Tempo</h2>
+                        <p class="text-sm text-white/70" data-i18n="careers.values.rhythm.body">
+                            Haftada dört gün stüdyoda, bir gün uzaktan ortak eskiz oturumları düzenliyoruz.
+                            Sunum dosyaları ekip içinde paylaşılıyor, revizyonlar hızla ilerliyor.
+                        </p>
+                    </div>
+                    <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                        <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="careers.values.mentoring.label">Mentorluk</p>
+                        <h2 class="text-xl font-display text-white" data-i18n="careers.values.mentoring.title">Beraber Öğrenme</h2>
+                        <p class="text-sm text-white/70" data-i18n="careers.values.mentoring.body">
+                            Yeni katılan ekip arkadaşları, stüdyo kurucu ortaklarıyla bire bir proje takip oturumlarına giriyor.
+                            Tüm sunum şablonlarını birlikte geliştiriyoruz.
+                        </p>
+                    </div>
+                    <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                        <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="careers.values.atmosphere.label">Ortam</p>
+                        <h2 class="text-xl font-display text-white" data-i18n="careers.values.atmosphere.title">Sıcak Stüdyo</h2>
+                        <p class="text-sm text-white/70" data-i18n="careers.values.atmosphere.body">
+                            Galata sokaklarındaki ritmi stüdyoya taşıyan samimi bir ekip var.
+                            Maket masası, ses sistemi ve fotoğraf köşesi her zaman açık.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="space-y-10">
+                <div class="flex items-start justify-between gap-8">
+                    <div class="space-y-4">
+                        <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="careers.roles.eyebrow">Açık Pozisyonlar</p>
+                        <h2 class="text-3xl font-display text-white md:text-4xl" data-i18n="careers.roles.title">Güncel Aradığımız Roller</h2>
+                        <p class="max-w-2xl text-sm text-white/70" data-i18n="careers.roles.description">
+                            Aşağıdaki roller için portfolyo, kısa niyet mektubu ve iletişim bilgilerinizi paylaşırsanız bir haftalık sürede geri dönüş yapıyoruz.
+                        </p>
+                    </div>
+                    <a class="hidden text-xs uppercase tracking-[0.45em] text-white/70 transition hover:text-white md:inline-flex" data-i18n="careers.roles.cta" href="mailto:kariyer@alpimimarlik.com">
+                        Başvuruyu Gönder
+                    </a>
+                </div>
+                <div class="space-y-6">
+                    <article class="grid gap-6 border border-white/10 bg-black/30 p-6 md:grid-cols-[1.2fr,1fr] md:items-center">
+                        <div class="space-y-3">
+                            <h3 class="text-2xl font-display text-white" data-i18n="careers.roles.positions.presentationArchitect.title">Sunum Mimarı</h3>
+                            <p class="text-sm text-white/70" data-i18n="careers.roles.positions.presentationArchitect.body">
+                                Konsept toplantılarında kullanılacak plan, kesit ve atmosfer panolarını hazırlayacak; maket çekimlerini katalog diline taşıyacak bir ekip arkadaşı arıyoruz.
+                                Rhino, Enscape ve Adobe InDesign kullanımı bekleniyor.
+                            </p>
+                            <ul class="space-y-2 text-sm text-white/60">
+                                <li data-i18n="careers.roles.positions.presentationArchitect.bullets.one">• 2-4 yıl mimari sunum deneyimi</li>
+                                <li data-i18n="careers.roles.positions.presentationArchitect.bullets.two">• Detaylı Türkçe metin ve kısa İngilizce özet yazabilme</li>
+                                <li data-i18n="careers.roles.positions.presentationArchitect.bullets.three">• Şantiye öncesi toplantılara katılım</li>
+                            </ul>
+                        </div>
+                        <div
+                            aria-label="Sunum ekibini anlatan konsept görsel"
+                            class="concept-visual h-48 w-full"
+                            role="img"
+                            style="background-image: radial-gradient(circle at 22% 28%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 52%), radial-gradient(circle at 78% 65%, rgba(255, 255, 255, 0.14) 0%, rgba(255, 255, 255, 0) 58%), linear-gradient(160deg, #161826, #22263a 60%, #352949));"
+                        ></div>
+                    </article>
+                    <article class="grid gap-6 border border-white/10 bg-black/30 p-6 md:grid-cols-[1.2fr,1fr] md:items-center">
+                        <div class="space-y-3">
+                            <h3 class="text-2xl font-display text-white" data-i18n="careers.roles.positions.visualDesigner.title">Görsel İletişim Tasarımcısı</h3>
+                            <p class="text-sm text-white/70" data-i18n="careers.roles.positions.visualDesigner.body">
+                                Kampanya lansmanlarında kullanılacak posterler, sosyal medya düzenleri ve sunum kapaklarını birlikte tasarlayacağız.
+                                Tasarım dilimizi korurken yeni tipografi önerileri getirecek bir ekip arkadaşı arıyoruz.
+                            </p>
+                            <ul class="space-y-2 text-sm text-white/60">
+                                <li data-i18n="careers.roles.positions.visualDesigner.bullets.one">• Adobe Illustrator ve Figma deneyimi</li>
+                                <li data-i18n="careers.roles.positions.visualDesigner.bullets.two">• Mimarlık görselleriyle çalışmaya yatkınlık</li>
+                                <li data-i18n="careers.roles.positions.visualDesigner.bullets.three">• Kısa süreli freelance iş birliklerine açık</li>
+                            </ul>
+                        </div>
+                        <div
+                            aria-label="Grafik tasarım masasını anlatan konsept görsel"
+                            class="concept-visual h-48 w-full"
+                            role="img"
+                            style="background-image: radial-gradient(circle at 30% 32%, rgba(255, 208, 158, 0.72) 0%, rgba(255, 208, 158, 0) 52%), radial-gradient(circle at 72% 68%, rgba(160, 214, 255, 0.55) 0%, rgba(160, 214, 255, 0) 48%), linear-gradient(155deg, #1c1e2c, #141723 58%, #2c243c));"
+                        ></div>
+                    </article>
+                    <article class="grid gap-6 border border-white/10 bg-black/30 p-6 md:grid-cols-[1.2fr,1fr] md:items-center">
+                        <div class="space-y-3">
+                            <h3 class="text-2xl font-display text-white" data-i18n="careers.roles.positions.studioIntern.title">Stüdyo Stajyeri</h3>
+                            <p class="text-sm text-white/70" data-i18n="careers.roles.positions.studioIntern.body">
+                                Yaz döneminde stüdyomuzda eskiz ve maket süreçlerine destek verecek, toplantı öncesi sunum klasörlerini düzenleyecek bir stajyer arıyoruz.
+                                Okul projelerindeki anlatım dilinizi görmek isteriz.
+                            </p>
+                            <ul class="space-y-2 text-sm text-white/60">
+                                <li data-i18n="careers.roles.positions.studioIntern.bullets.one">• 3. veya 4. sınıf mimarlık öğrencisi</li>
+                                <li data-i18n="careers.roles.positions.studioIntern.bullets.two">• Haftada en az üç gün stüdyoda bulunabilme</li>
+                                <li data-i18n="careers.roles.positions.studioIntern.bullets.three">• Model yapımında hassasiyet</li>
+                            </ul>
+                        </div>
+                        <div
+                            aria-label="Maket çalışmalarını anlatan konsept görsel"
+                            class="concept-visual h-48 w-full"
+                            role="img"
+                            style="background-image: radial-gradient(circle at 26% 70%, rgba(255, 174, 226, 0.58) 0%, rgba(255, 174, 226, 0) 50%), radial-gradient(circle at 74% 32%, rgba(255, 255, 255, 0.16) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #131522, #1d1f31 58%, #302544));"
+                        ></div>
+                    </article>
+                </div>
+            </section>
+
+            <section class="grid gap-10 border border-white/10 bg-black/25 p-8 md:grid-cols-[1.1fr,1fr] md:items-center">
+                <div class="space-y-5">
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="careers.application.eyebrow">Başvuru</p>
+                    <h2 class="text-3xl font-display text-white md:text-4xl" data-i18n="careers.application.title">Nasıl Başvurulur?</h2>
+                    <p class="text-sm text-white/70" data-i18n="careers.application.body1">
+                        Portfolyonuzu PDF formatında, maksimum 15 sayfa olacak şekilde düzenleyin.
+                        Kısa niyet mektubunda Alpimimarlık ekibiyle nasıl bir sunum geliştirmek istediğinizi anlatın.
+                        Referans olabilecek eğitmen veya önceki ekip arkadaşlarının iletişim bilgilerini eklemeyi unutmayın.
+                    </p>
+                    <p class="text-sm text-white/70" data-i18n="careers.application.body2">
+                        Başvurular kariyer@alpimimarlik.com adresine gönderiliyor. Bir hafta içerisinde toplantı veya portfolyo geri bildirimi için iletişime geçiyoruz.
+                    </p>
+                </div>
+                <div class="space-y-6">
+                    <div
+                        aria-label="Başvuru dosyasını anlatan konsept görsel"
+                        class="concept-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 24% 34%, rgba(255, 208, 158, 0.65) 0%, rgba(255, 208, 158, 0) 50%), radial-gradient(circle at 76% 70%, rgba(164, 214, 255, 0.55) 0%, rgba(164, 214, 255, 0) 50%), linear-gradient(160deg, #1b1d2b, #11131f 62%, #2d253a));"
+                    ></div>
+                    <a class="inline-flex items-center justify-center border border-white/20 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.4em] text-white transition hover:bg-white/20" data-i18n="careers.application.cta" href="mailto:kariyer@alpimimarlik.com">
+                        Başvuruyu Paylaş
+                    </a>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="common.brand" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white" data-i18n="common.menuPanel.title">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html" data-i18n="common.nav.home">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html" data-i18n="common.nav.studio">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html" data-i18n="common.nav.services">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html" data-i18n="common.nav.insights">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html" data-i18n="common.nav.contact">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40" data-i18n="common.menuPanel.contactHeading">İletişim</p>
+                <p data-i18n="common.menuPanel.contactBody">Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white" data-i18n="common.footer.title">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400" data-i18n="common.footer.tagline">                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.navigate">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html" data-i18n="common.nav.home">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html" data-i18n="common.nav.studio">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html" data-i18n="common.nav.services">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html" data-i18n="common.nav.insights">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html" data-i18n="common.nav.contact">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.connect">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.instagram">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.linkedin">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.behance">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.youtube">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.newsletter">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        data-i18n-placeholder="common.footer.newsletterPlaceholder" placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit" data-i18n="common.footer.newsletterButton">Join</button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p data-i18n="common.footer.copyright">© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/i18n.js"></script>
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+    </script>
+</body>
+</html>

--- a/services.html
+++ b/services.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title data-i18n="meta.titles.services">Services — Alpimimarlık</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .concept-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .concept-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black px-8 py-5 text-white md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white" data-i18n="common.brand">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" data-i18n="common.langLabel" for="langSwitcher">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="langSwitcher"
+                >
+                    <option data-i18n="common.language.tr" value="tr">TR</option>
+                    <option data-i18n="common.language.en" value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span data-i18n="common.menuButton">Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="max-w-5xl space-y-12">
+            <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="services.hero.eyebrow">Hizmet Paketleri</p>
+            <h1 class="text-4xl font-display text-white md:text-5xl" data-i18n="services.hero.title">Sunum Odaklı Mimarlık Servisleri</h1>
+            <p class="text-base text-white/70" data-i18n="services.hero.body">
+                Küçük ölçekli ofislerin konseptlerini sahneleyen tanıtım paketleri hazırlıyoruz.
+                Ölçekli çizimler, atmosfer görselleri ve kısa metin blokları, ilk görüşmede güven veren bir vitrin sunmanıza yardımcı oluyor.
+            </p>
+            <div class="grid gap-10 md:grid-cols-2">
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Vizyon kitabı için hazırlanan konsept görsel"
+                        class="concept-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 22% 25%, rgba(255, 206, 165, 0.8) 0%, rgba(255, 206, 165, 0) 55%), radial-gradient(circle at 78% 70%, rgba(255, 132, 132, 0.48) 0%, rgba(255, 132, 132, 0) 50%), linear-gradient(150deg, #1f1f2f, #101019 58%, #2f253a);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="services.packages.visionBook.index">01</p>
+                    <h2 class="text-2xl font-display text-white" data-i18n="services.packages.visionBook.title">Vizyon Kitabı</h2>
+                    <p class="text-sm text-white/70" data-i18n="services.packages.visionBook.body">
+                        Üç bölümlü dijital kitap, lobi, çalışma alanı ve cephe sahnelerini aynı dilde anlatır.
+                        Renderlar ve fotoğraf düzenlemeleri, başlıklarla birlikte kullanılmaya hazır halde teslim edilir.
+                    </p>
+                </div>
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Sunum sahnesi paketine ait storyboard"
+                        class="concept-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 65% 35%, rgba(162, 216, 255, 0.7) 0%, rgba(162, 216, 255, 0) 55%), radial-gradient(circle at 20% 75%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(160deg, #1b2436, #0f141f 60%, #293347);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="services.packages.presentationScene.index">02</p>
+                    <h2 class="text-2xl font-display text-white" data-i18n="services.packages.presentationScene.title">Sunum Sahnesi</h2>
+                    <p class="text-sm text-white/70" data-i18n="services.packages.presentationScene.body">
+                        Pitch toplantıları için hazırlanan bu paket, hareketli slayt akışı ve kısa tanıtım filmiyle desteklenir.
+                        Boş ekranları, ofis kimliğinize uygun kolaj ve plan detaylarıyla tamamlıyoruz.
+                    </p>
+                </div>
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Dijital basın dosyasına ait kolaj"
+                        class="concept-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 50%), radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #131422, #1d1f31 58%, #332645);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="services.packages.pressKit.index">03</p>
+                    <h2 class="text-2xl font-display text-white" data-i18n="services.packages.pressKit.title">Dijital Basın Dosyası</h2>
+                    <p class="text-sm text-white/70" data-i18n="services.packages.pressKit.body">
+                        Basın bültenleri ve sosyal medya lansmanları için hızlıca özelleştirebileceğiniz şablonlar içerir.
+                        Her görsel, stüdyonuzun tonunu anlatan kısa açıklamalarla birlikte gelir.
+                    </p>
+                </div>
+                <div class="space-y-4 border border-white/10 bg-black/30 p-6">
+                    <div
+                        aria-label="Atölye oturumu için hazırlanan görsel"
+                        class="concept-visual h-40 w-full"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 70% 25%, rgba(255, 208, 158, 0.7) 0%, rgba(255, 208, 158, 0) 52%), radial-gradient(circle at 20% 70%, rgba(161, 218, 255, 0.6) 0%, rgba(161, 218, 255, 0) 45%), linear-gradient(155deg, #181a27, #0f1119 58%, #2b253a);"
+                    ></div>
+                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="services.packages.consulting.index">04</p>
+                    <h2 class="text-2xl font-display text-white" data-i18n="services.packages.consulting.title">Danışmanlık &amp; Koordinasyon</h2>
+                    <p class="text-sm text-white/70" data-i18n="services.packages.consulting.body">
+                        Sunum hazırlıkları sırasında ekiplerinizi yönlendiren toplantılar planlıyoruz.
+                        Malzeme seçimi, metin tonu ve görsel yerleşimleri için paylaşılabilir rehberler sunuyoruz.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="common.brand" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white" data-i18n="common.menuPanel.title">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html" data-i18n="common.nav.home">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html" data-i18n="common.nav.studio">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html" data-i18n="common.nav.services">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html" data-i18n="common.nav.insights">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html" data-i18n="common.nav.contact">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40" data-i18n="common.menuPanel.contactHeading">İletişim</p>
+                <p data-i18n="common.menuPanel.contactBody">Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white" data-i18n="common.footer.title">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400" data-i18n="common.footer.tagline">                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.navigate">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html" data-i18n="common.nav.home">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html" data-i18n="common.nav.studio">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html" data-i18n="common.nav.services">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html" data-i18n="common.nav.insights">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html" data-i18n="common.nav.contact">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.connect">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.instagram">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.linkedin">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.behance">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.youtube">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.newsletter">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        data-i18n-placeholder="common.footer.newsletterPlaceholder" placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit" data-i18n="common.footer.newsletterButton">Join</button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p data-i18n="common.footer.copyright">© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/i18n.js"></script>
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+    </script>
+</body>
+</html>

--- a/studio.html
+++ b/studio.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html class="dark" lang="tr">
+<head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title data-i18n="meta.titles.studio">Studio — Alpimimarlık</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#E2E2E2",
+                        "background-light": "#F5F5F5",
+                        "background-dark": "#0B0B0B",
+                        accent: "#BFBFBF",
+                    },
+                    fontFamily: {
+                        display: ["Roboto Condensed", "sans-serif"],
+                        body: ["Roboto", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.125rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .concept-visual {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.25rem;
+            background-size: 160%;
+            background-position: center;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .concept-visual::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body class="bg-background-dark text-primary font-body antialiased">
+    <header class="border-b border-white/10 bg-black px-8 py-5 text-white md:px-16">
+        <div class="flex items-center justify-between gap-8">
+            <a class="text-sm font-display uppercase tracking-[0.6em] text-white/80" href="index.html">
+                <span class="font-bold text-white" data-i18n="common.brand">Alpimimarlık</span>
+            </a>
+            <div class="flex items-center gap-4">
+                <label class="sr-only" data-i18n="common.langLabel" for="langSwitcher">Dil Seçimi</label>
+                <select
+                    class="hidden appearance-none rounded-sm border border-white/30 bg-black/40 px-3 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 shadow-sm transition focus:border-white focus:outline-none md:block"
+                    id="langSwitcher"
+                >
+                    <option data-i18n="common.language.tr" value="tr">TR</option>
+                    <option data-i18n="common.language.en" value="en">EN</option>
+                </select>
+                <button
+                    class="flex items-center gap-2 text-xs uppercase tracking-[0.45em] text-white/70 transition-opacity hover:opacity-60"
+                    id="menu-toggle"
+                    type="button"
+                >
+                    <span class="material-icons text-base">menu</span>
+                    <span data-i18n="common.menuButton">Menü</span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-8 py-20 text-primary md:px-20">
+        <div class="max-w-4xl space-y-10">
+            <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="studio.hero.eyebrow">Stüdyo Hikâyesi</p>
+            <h1 class="text-4xl font-display text-white md:text-5xl" data-i18n="studio.hero.title">Stüdyonun Arka Planı</h1>
+            <p class="text-base text-white/70" data-i18n="studio.hero.body">
+                Alpimimarlık, Galata merkezli küçük bir mimarlık ofisi.
+                Tanıtım kitapçıklarında boş kalan bölümleri, ekip içinde hazırladığımız konsept görselleriyle dolduruyor ve sunumların sıcak bir dilde ilerlemesini sağlıyoruz.
+            </p>
+            <div class="grid gap-6 md:grid-cols-3">
+                <figure class="overflow-hidden rounded-sm border border-white/10 bg-black/40">
+                    <div
+                        aria-label="Çalışma masalarının yer aldığı stüdyo görseli"
+                        class="concept-visual h-48"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 25% 25%, rgba(255, 208, 158, 0.8) 0%, rgba(255, 208, 158, 0) 55%), radial-gradient(circle at 75% 70%, rgba(255, 126, 126, 0.5) 0%, rgba(255, 126, 126, 0) 45%), linear-gradient(145deg, #222232, #101019 60%, #30253e);"
+                    ></div>
+                    <figcaption class="p-4 text-xs uppercase tracking-[0.35em] text-white/60" data-i18n="studio.gallery.caption1">Planlama Odası</figcaption>
+                </figure>
+                <figure class="overflow-hidden rounded-sm border border-white/10 bg-black/40">
+                    <div
+                        aria-label="Giriş holünü gösteren render"
+                        class="concept-visual h-48"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 70% 30%, rgba(160, 214, 255, 0.75) 0%, rgba(160, 214, 255, 0) 55%), radial-gradient(circle at 20% 75%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(150deg, #1b2435, #0f141f 58%, #2a3247);"
+                    ></div>
+                    <figcaption class="p-4 text-xs uppercase tracking-[0.35em] text-white/60" data-i18n="studio.gallery.caption2">Lobi Vinyeti</figcaption>
+                </figure>
+                <figure class="overflow-hidden rounded-sm border border-white/10 bg-black/40">
+                    <div
+                        aria-label="Gece cephe aydınlatmasını betimleyen görsel"
+                        class="concept-visual h-48"
+                        role="img"
+                        style="background-image: radial-gradient(circle at 20% 70%, rgba(255, 172, 225, 0.55) 0%, rgba(255, 172, 225, 0) 52%), radial-gradient(circle at 80% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #121422, #1c1f31 55%, #302445);"
+                    ></div>
+                    <figcaption class="p-4 text-xs uppercase tracking-[0.35em] text-white/60" data-i18n="studio.gallery.caption3">Cephe Senaryosu</figcaption>
+                </figure>
+            </div>
+            <div class="space-y-6">
+                <h2 class="text-2xl font-display text-white" data-i18n="studio.approach.title">Yaklaşımımız</h2>
+                <p class="text-sm text-white/70" data-i18n="studio.approach.body1">
+                    Toplantı öncesi paylaşılan kitapçıklarda, ölçeksiz eskizleri ve stüdyomuzda hazırlanan sahne önerilerini yan yana kurguluyoruz.
+                    Her görsel, mekânın hissini anlatan kısa notlarla destekleniyor.
+                </p>
+                <p class="text-sm text-white/70" data-i18n="studio.approach.body2">
+                    Bu sayede uygulama dosyası tamamlanmadan önce bile yatırımcılara ofisin karakterini net şekilde gösteren tanıtım klasörleri hazırlıyoruz.
+                </p>
+            </div>
+        </div>
+    </main>
+
+    <div
+        aria-labelledby="menu-title"
+        aria-modal="true"
+        class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 backdrop-blur-md transition-opacity"
+        id="menu-panel"
+        role="dialog"
+    >
+        <div class="ml-auto flex h-full w-full max-w-xs flex-col border-l border-white/10 bg-background-dark/95 p-8 text-white shadow-2xl sm:max-w-sm">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.55em] text-accent" data-i18n="common.brand" id="menu-title">Alpimimarlık</p>
+                    <h2 class="mt-3 text-2xl font-display text-white" data-i18n="common.menuPanel.title">Tanıtım Menüsü</h2>
+                </div>
+                <button class="text-white/60 transition hover:text-white" id="menu-close" type="button">
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+            <nav class="mt-10 space-y-6 text-sm uppercase tracking-[0.4em] text-white/70">
+                <a class="block transition-opacity hover:opacity-60" href="index.html" data-i18n="common.nav.home">Ana Sayfa</a>
+                <a class="block transition-opacity hover:opacity-60" href="studio.html" data-i18n="common.nav.studio">Studio</a>
+                <a class="block transition-opacity hover:opacity-60" href="services.html" data-i18n="common.nav.services">Services</a>
+                <a class="block transition-opacity hover:opacity-60" href="insights.html" data-i18n="common.nav.insights">Insights</a>
+                <a class="block transition-opacity hover:opacity-60" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a>
+                <a class="block transition-opacity hover:opacity-60" href="contact.html" data-i18n="common.nav.contact">Contact</a>
+            </nav>
+            <div class="mt-auto space-y-4 text-sm text-white/60">
+                <p class="uppercase tracking-[0.35em] text-white/40" data-i18n="common.menuPanel.contactHeading">İletişim</p>
+                <p data-i18n="common.menuPanel.contactBody">Galata merkezli ofis, sunum ve konsept kitapçıkları hazırlıyor.</p>
+                <a class="inline-flex items-center gap-2 text-white transition hover:text-white/70" href="mailto:iletisim@alpimimarlik.com">
+                    <span class="material-icons text-base">mail</span>
+                    <span>iletisim@alpimimarlik.com</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="border-t border-white/10 bg-black px-8 py-16 text-primary md:px-20">
+        <div class="grid grid-cols-1 gap-12 md:grid-cols-4">
+            <div>
+                <h3 class="text-xl font-display font-bold tracking-tight text-white" data-i18n="common.footer.title">Alpimimarlık</h3>
+                <p class="mt-3 text-sm text-gray-400" data-i18n="common.footer.tagline">                    Pioneering architectural narratives shaped by context, craft, and human experience.
+                </p>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.navigate">Navigate</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="index.html" data-i18n="common.nav.home">Home</a></li>
+                    <li><a class="transition-colors hover:text-white" href="studio.html" data-i18n="common.nav.studio">Studio</a></li>
+                    <li><a class="transition-colors hover:text-white" href="services.html" data-i18n="common.nav.services">Services</a></li>
+                    <li><a class="transition-colors hover:text-white" href="insights.html" data-i18n="common.nav.insights">Insights</a></li>
+                    <li><a class="transition-colors hover:text-white" href="kariyer.html" data-i18n="common.nav.careers">Kariyer</a></li>
+                    <li><a class="transition-colors hover:text-white" href="contact.html" data-i18n="common.nav.contact">Contact</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.connect">Connect</h3>
+                <ul class="mt-4 space-y-3 text-sm text-gray-400">
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.instagram">Instagram</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.linkedin">LinkedIn</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.behance">Behance</a></li>
+                    <li><a class="transition-colors hover:text-white" href="#" data-i18n="common.footer.youtube">YouTube</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-display uppercase tracking-[0.45em] text-white/70" data-i18n="common.footer.newsletter">Newsletter</h3>
+                <form class="mt-4 space-y-3">
+                    <input
+                        class="w-full border border-white/15 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                        data-i18n-placeholder="common.footer.newsletterPlaceholder" placeholder="Enter your email"
+                        type="email"
+                    />
+                    <button class="w-full bg-white/10 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/20" type="submit" data-i18n="common.footer.newsletterButton">Join</button>
+                </form>
+            </div>
+        </div>
+        <div class="mt-14 border-t border-white/10 pt-6 text-xs text-white/40">
+            <p data-i18n="common.footer.copyright">© 2024 Alpimimarlık. Tüm hakları saklıdır.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/i18n.js"></script>
+    <script>
+        const menuToggle = document.getElementById('menu-toggle');
+        const menuPanel = document.getElementById('menu-panel');
+        const menuClose = document.getElementById('menu-close');
+
+        const openMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('hidden');
+            menuPanel.classList.remove('opacity-0');
+            requestAnimationFrame(() => menuPanel.classList.add('opacity-100'));
+        };
+
+        const closeMenuPanel = () => {
+            if (!menuPanel) return;
+            menuPanel.classList.remove('opacity-100');
+            menuPanel.classList.add('opacity-0');
+            setTimeout(() => menuPanel.classList.add('hidden'), 180);
+        };
+
+        if (menuToggle) {
+            menuToggle.addEventListener('click', openMenuPanel);
+        }
+
+        if (menuClose) {
+            menuClose.addEventListener('click', closeMenuPanel);
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && menuPanel && !menuPanel.classList.contains('hidden')) {
+                closeMenuPanel();
+            }
+        });
+
+        if (menuPanel) {
+            menuPanel.addEventListener('click', (event) => {
+                if (event.target === menuPanel) {
+                    closeMenuPanel();
+                }
+            });
+
+            menuPanel.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', closeMenuPanel);
+            });
+        }
+
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- localize the Turkish navigation, footer, and hero hint strings so the default language no longer shows English labels
- keep the English dictionary in sync while normalizing its formatting for consistent JSON output

## Testing
- python -m json.tool i18n/tr.json
- python -m json.tool i18n/en.json
- python - <<'PY'
import os,re,json
html_files=[f for f in os.listdir('.') if f.endswith('.html')]
attr_re=re.compile(r'data-i18n(?:-[^=]+)?="([^"]+)"')
keys=set()
for f in html_files:
    with open(f,encoding='utf-8') as fh:
        text=fh.read()
    for m in attr_re.finditer(text):
        keys.add(m.group(1))

with open('i18n/tr.json',encoding='utf-8') as fh:
    tr=json.load(fh)
with open('i18n/en.json',encoding='utf-8') as fh:
    en=json.load(fh)

def get(d,key):
    cur=d
    for part in key.split('.'):
        if isinstance(cur,dict) and part in cur:
            cur=cur[part]
        else:
            return False
    return True

missing_tr=[k for k in keys if not get(tr,k)]
missing_en=[k for k in keys if not get(en,k)]
print('missing_tr',missing_tr)
print('missing_en',missing_en)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d53a8c5f108325b25812249027112e