### PR TITLE
Add Node.js backend and admin panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+uploads/*.pdf
+uploads/*.PDF

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,26 @@
+const jwt = require('jsonwebtoken');
+
+const JWT_SECRET = process.env.JWT_SECRET || 'supersecretjwt';
+
+module.exports = function auth(req, res, next) {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader) {
+    return res.status(401).json({ message: 'Yetkisiz: Token bulunamadı.' });
+  }
+
+  const [scheme, token] = authHeader.split(' ');
+
+  if (scheme !== 'Bearer' || !token) {
+    return res.status(401).json({ message: 'Yetkisiz: Bearer token gerekli.' });
+  }
+
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (error) {
+    console.error('JWT doğrulaması başarısız:', error.message);
+    return res.status(401).json({ message: 'Yetkisiz: Token geçersiz veya süresi dolmuş.' });
+  }
+};

--- a/models/CV.js
+++ b/models/CV.js
@@ -1,0 +1,31 @@
+const mongoose = require('mongoose');
+
+const cvSchema = new mongoose.Schema(
+  {
+    filename: {
+      type: String,
+      required: true,
+    },
+    originalname: {
+      type: String,
+      required: true,
+    },
+    mimetype: {
+      type: String,
+      required: true,
+    },
+    size: {
+      type: Number,
+      required: true,
+    },
+    uploadDate: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+module.exports = mongoose.model('CV', cvSchema);

--- a/models/Content.js
+++ b/models/Content.js
@@ -1,0 +1,24 @@
+const mongoose = require('mongoose');
+
+const contentSchema = new mongoose.Schema(
+  {
+    title: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    body: {
+      type: String,
+      required: true,
+    },
+    date: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+module.exports = mongoose.model('Content', contentSchema);

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,21 @@
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema(
+  {
+    username: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+    },
+    password: {
+      type: String,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+module.exports = mongoose.model('User', userSchema);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "alpermorkoc-backend",
+  "version": "1.0.0",
+  "description": "Backend ve admin paneli",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "bcrypt": "^5.1.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^7.5.0",
+    "multer": "^1.4.5-lts.1"
+  }
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="tr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Paneli</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        margin: 0;
+        background: #f3f4f6;
+        color: #1f2933;
+      }
+      header {
+        background: #111827;
+        color: #f9fafb;
+        padding: 1.5rem 2rem;
+        text-align: center;
+      }
+      main {
+        max-width: 1100px;
+        margin: 2rem auto;
+        padding: 0 1rem 3rem;
+      }
+      section {
+        background: #ffffff;
+        border-radius: 12px;
+        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+        margin-bottom: 2rem;
+        padding: 1.5rem;
+      }
+      h2 {
+        margin-top: 0;
+      }
+      form {
+        display: grid;
+        gap: 1rem;
+      }
+      label {
+        font-weight: 600;
+      }
+      input[type='text'],
+      input[type='password'],
+      textarea {
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        border: 1px solid #d1d5db;
+        font-size: 1rem;
+      }
+      textarea {
+        min-height: 120px;
+      }
+      input[type='file'] {
+        padding: 0.75rem 0;
+      }
+      button {
+        background: #2563eb;
+        color: #ffffff;
+        padding: 0.75rem 1.5rem;
+        border: none;
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 1rem;
+        font-weight: 600;
+      }
+      button.secondary {
+        background: #6b7280;
+      }
+      button.danger {
+        background: #dc2626;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th,
+      td {
+        border-bottom: 1px solid #e5e7eb;
+        padding: 0.75rem;
+        text-align: left;
+      }
+      tr:last-child td {
+        border-bottom: none;
+      }
+      .actions {
+        display: flex;
+        gap: 0.5rem;
+      }
+      .hidden {
+        display: none !important;
+      }
+      .status {
+        margin-top: 1rem;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        background: #eff6ff;
+        color: #1e40af;
+        display: none;
+      }
+      @media (max-width: 768px) {
+        table {
+          display: block;
+          overflow-x: auto;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Admin Paneli</h1>
+    </header>
+    <main>
+      <section id="login-section">
+        <h2>Admin Girişi</h2>
+        <form id="login-form">
+          <div>
+            <label for="username">Kullanıcı Adı</label>
+            <input type="text" id="username" name="username" required />
+          </div>
+          <div>
+            <label for="password">Parola</label>
+            <input type="password" id="password" name="password" required />
+          </div>
+          <button type="submit">Giriş Yap</button>
+        </form>
+        <div class="status" id="login-status"></div>
+      </section>
+
+      <section id="admin-section" class="hidden">
+        <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap;">
+          <h2>Yönetim</h2>
+          <button id="logout-button" class="secondary">Çıkış Yap</button>
+        </div>
+
+        <section>
+          <h3>Yeni İçerik Ekle</h3>
+          <form id="create-content-form">
+            <div>
+              <label for="create-title">Başlık</label>
+              <input type="text" id="create-title" name="title" required />
+            </div>
+            <div>
+              <label for="create-body">İçerik</label>
+              <textarea id="create-body" name="body" required></textarea>
+            </div>
+            <button type="submit">Ekle</button>
+          </form>
+        </section>
+
+        <section>
+          <h3>İçerikler</h3>
+          <div style="overflow-x: auto;">
+            <table>
+              <thead>
+                <tr>
+                  <th>Başlık</th>
+                  <th>İçerik</th>
+                  <th>Tarih</th>
+                  <th>İşlemler</th>
+                </tr>
+              </thead>
+              <tbody id="content-table-body"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section id="update-section" class="hidden">
+          <h3>İçerik Güncelle</h3>
+          <form id="update-content-form">
+            <input type="hidden" id="update-id" />
+            <div>
+              <label for="update-title">Başlık</label>
+              <input type="text" id="update-title" name="title" required />
+            </div>
+            <div>
+              <label for="update-body">İçerik</label>
+              <textarea id="update-body" name="body" required></textarea>
+            </div>
+            <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+              <button type="submit">Güncelle</button>
+              <button type="button" id="cancel-update" class="secondary">İptal</button>
+            </div>
+          </form>
+        </section>
+
+        <section>
+          <h3>CV Yükle</h3>
+          <form id="upload-cv-form">
+            <div>
+              <label for="cv-file">PDF Seç</label>
+              <input type="file" id="cv-file" name="cv" accept="application/pdf" required />
+            </div>
+            <button type="submit">Yükle</button>
+          </form>
+        </section>
+
+        <section>
+          <h3>CV Listesi</h3>
+          <div style="overflow-x: auto;">
+            <table>
+              <thead>
+                <tr>
+                  <th>Dosya Adı</th>
+                  <th>Tip</th>
+                  <th>Boyut</th>
+                  <th>Yüklenme Tarihi</th>
+                  <th>İşlemler</th>
+                </tr>
+              </thead>
+              <tbody id="cv-table-body"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <div class="status" id="admin-status"></div>
+      </section>
+    </main>
+    <script src="admin.js" defer></script>
+  </body>
+</html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,0 +1,465 @@
+const API_BASE = '/api';
+
+const loginSection = document.getElementById('login-section');
+const adminSection = document.getElementById('admin-section');
+const loginForm = document.getElementById('login-form');
+const createContentForm = document.getElementById('create-content-form');
+const updateContentForm = document.getElementById('update-content-form');
+const uploadCvForm = document.getElementById('upload-cv-form');
+const logoutButton = document.getElementById('logout-button');
+const cancelUpdateButton = document.getElementById('cancel-update');
+const loginStatus = document.getElementById('login-status');
+const adminStatus = document.getElementById('admin-status');
+const contentTableBody = document.getElementById('content-table-body');
+const cvTableBody = document.getElementById('cv-table-body');
+const updateSection = document.getElementById('update-section');
+const updateIdInput = document.getElementById('update-id');
+const updateTitleInput = document.getElementById('update-title');
+const updateBodyInput = document.getElementById('update-body');
+
+let token = localStorage.getItem('adminToken') || '';
+
+function setStatus(element, message, isError = false) {
+  if (!element) return;
+  if (!message) {
+    element.style.display = 'none';
+    element.textContent = '';
+    return;
+  }
+  element.textContent = message;
+  element.style.display = 'block';
+  element.style.backgroundColor = isError ? '#fee2e2' : '#eff6ff';
+  element.style.color = isError ? '#b91c1c' : '#1e40af';
+}
+
+function toggleSections() {
+  if (token) {
+    loginSection.classList.add('hidden');
+    adminSection.classList.remove('hidden');
+    initializeAdminData();
+  } else {
+    adminSection.classList.add('hidden');
+    loginSection.classList.remove('hidden');
+    setStatus(adminStatus, '');
+    setStatus(loginStatus, '');
+  }
+}
+
+async function login(event) {
+  event.preventDefault();
+  setStatus(loginStatus, 'Giriş yapılıyor...');
+
+  const formData = new FormData(loginForm);
+  const payload = Object.fromEntries(formData.entries());
+
+  try {
+    const response = await fetch(`${API_BASE}/login`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({ message: 'Giriş başarısız.' }));
+      setStatus(loginStatus, data.message || 'Giriş başarısız.', true);
+      return;
+    }
+
+    const data = await response.json();
+    token = data.token;
+    localStorage.setItem('adminToken', token);
+    loginForm.reset();
+    setStatus(loginStatus, 'Giriş başarılı.');
+    toggleSections();
+  } catch (error) {
+    console.error('Login isteği başarısız:', error);
+    setStatus(loginStatus, 'Sunucuya ulaşılamadı.', true);
+  }
+}
+
+async function initializeAdminData() {
+  await Promise.all([fetchContents(), fetchCvs()]);
+}
+
+function authHeaders() {
+  return token
+    ? {
+        Authorization: `Bearer ${token}`,
+      }
+    : {};
+}
+
+async function fetchContents() {
+  try {
+    const response = await fetch(`${API_BASE}/content`);
+    if (!response.ok) {
+      throw new Error('İçerikler alınamadı.');
+    }
+    const contents = await response.json();
+    renderContents(contents);
+  } catch (error) {
+    console.error(error);
+    setStatus(adminStatus, 'İçerikler alınamadı.', true);
+  }
+}
+
+function renderContents(contents) {
+  if (!Array.isArray(contents)) return;
+  contentTableBody.innerHTML = '';
+
+  if (contents.length === 0) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 4;
+    cell.textContent = 'Henüz içerik yok.';
+    row.appendChild(cell);
+    contentTableBody.appendChild(row);
+    return;
+  }
+
+  contents.forEach((content) => {
+    const row = document.createElement('tr');
+
+    const titleCell = document.createElement('td');
+    titleCell.textContent = content.title;
+
+    const bodyCell = document.createElement('td');
+    bodyCell.textContent = content.body;
+
+    const dateCell = document.createElement('td');
+    dateCell.textContent = formatDate(content.date || content.createdAt);
+
+    const actionsCell = document.createElement('td');
+    actionsCell.classList.add('actions');
+
+    const editButton = document.createElement('button');
+    editButton.textContent = 'Düzenle';
+    editButton.type = 'button';
+    editButton.addEventListener('click', () => startUpdate(content));
+
+    const deleteButton = document.createElement('button');
+    deleteButton.textContent = 'Sil';
+    deleteButton.type = 'button';
+    deleteButton.classList.add('danger');
+    deleteButton.addEventListener('click', () => deleteContent(content._id));
+
+    actionsCell.appendChild(editButton);
+    actionsCell.appendChild(deleteButton);
+
+    row.appendChild(titleCell);
+    row.appendChild(bodyCell);
+    row.appendChild(dateCell);
+    row.appendChild(actionsCell);
+
+    contentTableBody.appendChild(row);
+  });
+}
+
+function formatDate(dateString) {
+  if (!dateString) return '-';
+  const date = new Date(dateString);
+  return new Intl.DateTimeFormat('tr-TR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+async function createContent(event) {
+  event.preventDefault();
+  setStatus(adminStatus, 'İçerik ekleniyor...');
+
+  const formData = new FormData(createContentForm);
+  const payload = Object.fromEntries(formData.entries());
+
+  try {
+    const response = await fetch(`${API_BASE}/content`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeaders(),
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (response.status === 401) {
+      handleUnauthorized();
+      return;
+    }
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({ message: 'İçerik eklenemedi.' }));
+      throw new Error(data.message);
+    }
+
+    createContentForm.reset();
+    setStatus(adminStatus, 'İçerik başarıyla eklendi.');
+    await fetchContents();
+  } catch (error) {
+    console.error('İçerik eklenemedi:', error);
+    setStatus(adminStatus, error.message || 'İçerik eklenemedi.', true);
+  }
+}
+
+function startUpdate(content) {
+  updateSection.classList.remove('hidden');
+  updateIdInput.value = content._id;
+  updateTitleInput.value = content.title || '';
+  updateBodyInput.value = content.body || '';
+  window.scrollTo({ top: updateSection.offsetTop - 20, behavior: 'smooth' });
+}
+
+async function updateContent(event) {
+  event.preventDefault();
+  const id = updateIdInput.value;
+  if (!id) {
+    setStatus(adminStatus, 'Güncellenecek içerik seçilmedi.', true);
+    return;
+  }
+
+  const formData = new FormData(updateContentForm);
+  const payload = Object.fromEntries(formData.entries());
+
+  try {
+    const response = await fetch(`${API_BASE}/content/${id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeaders(),
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (response.status === 401) {
+      handleUnauthorized();
+      return;
+    }
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({ message: 'İçerik güncellenemedi.' }));
+      throw new Error(data.message);
+    }
+
+    setStatus(adminStatus, 'İçerik güncellendi.');
+    updateContentForm.reset();
+    updateSection.classList.add('hidden');
+    await fetchContents();
+  } catch (error) {
+    console.error('İçerik güncellenemedi:', error);
+    setStatus(adminStatus, error.message || 'İçerik güncellenemedi.', true);
+  }
+}
+
+async function deleteContent(id) {
+  if (!id) return;
+  const confirmation = confirm('Bu içeriği silmek istediğinize emin misiniz?');
+  if (!confirmation) return;
+
+  try {
+    const response = await fetch(`${API_BASE}/content/${id}`, {
+      method: 'DELETE',
+      headers: {
+        ...authHeaders(),
+      },
+    });
+
+    if (response.status === 401) {
+      handleUnauthorized();
+      return;
+    }
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({ message: 'İçerik silinemedi.' }));
+      throw new Error(data.message);
+    }
+
+    setStatus(adminStatus, 'İçerik silindi.');
+    await fetchContents();
+  } catch (error) {
+    console.error('İçerik silinemedi:', error);
+    setStatus(adminStatus, error.message || 'İçerik silinemedi.', true);
+  }
+}
+
+async function uploadCv(event) {
+  event.preventDefault();
+  setStatus(adminStatus, 'CV yükleniyor...');
+
+  const formData = new FormData(uploadCvForm);
+
+  try {
+    const response = await fetch(`${API_BASE}/upload-cv`, {
+      method: 'POST',
+      headers: {
+        ...authHeaders(),
+      },
+      body: formData,
+    });
+
+    if (response.status === 401) {
+      handleUnauthorized();
+      return;
+    }
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({ message: 'CV yüklenemedi.' }));
+      throw new Error(data.message);
+    }
+
+    uploadCvForm.reset();
+    setStatus(adminStatus, 'CV başarıyla yüklendi.');
+    await fetchCvs();
+  } catch (error) {
+    console.error('CV yüklenemedi:', error);
+    setStatus(adminStatus, error.message || 'CV yüklenemedi.', true);
+  }
+}
+
+async function fetchCvs() {
+  try {
+    const response = await fetch(`${API_BASE}/cvs`, {
+      headers: {
+        ...authHeaders(),
+      },
+    });
+
+    if (response.status === 401) {
+      handleUnauthorized();
+      return;
+    }
+
+    if (!response.ok) {
+      throw new Error('CV listesi alınamadı.');
+    }
+
+    const cvs = await response.json();
+    renderCvList(cvs);
+  } catch (error) {
+    console.error('CV listesi alınamadı:', error);
+    setStatus(adminStatus, 'CV listesi alınamadı.', true);
+  }
+}
+
+function renderCvList(cvs) {
+  cvTableBody.innerHTML = '';
+  if (!Array.isArray(cvs) || cvs.length === 0) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 5;
+    cell.textContent = 'Henüz yüklenmiş CV bulunmuyor.';
+    row.appendChild(cell);
+    cvTableBody.appendChild(row);
+    return;
+  }
+
+  cvs.forEach((cv) => {
+    const row = document.createElement('tr');
+
+    const nameCell = document.createElement('td');
+    nameCell.textContent = cv.originalname || cv.filename;
+
+    const typeCell = document.createElement('td');
+    typeCell.textContent = cv.mimetype;
+
+    const sizeCell = document.createElement('td');
+    sizeCell.textContent = formatFileSize(cv.size);
+
+    const dateCell = document.createElement('td');
+    dateCell.textContent = formatDate(cv.uploadDate || cv.createdAt);
+
+    const actionsCell = document.createElement('td');
+    const downloadButton = document.createElement('button');
+    downloadButton.type = 'button';
+    downloadButton.textContent = 'İndir';
+    downloadButton.addEventListener('click', () => downloadCv(cv._id, cv.originalname));
+
+    actionsCell.appendChild(downloadButton);
+
+    row.appendChild(nameCell);
+    row.appendChild(typeCell);
+    row.appendChild(sizeCell);
+    row.appendChild(dateCell);
+    row.appendChild(actionsCell);
+
+    cvTableBody.appendChild(row);
+  });
+}
+
+function formatFileSize(bytes) {
+  if (!bytes && bytes !== 0) return '-';
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  if (bytes === 0) return '0 B';
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const value = bytes / Math.pow(1024, i);
+  return `${value.toFixed(1)} ${sizes[i] || 'B'}`;
+}
+
+async function downloadCv(id, originalName = 'cv.pdf') {
+  try {
+    const response = await fetch(`${API_BASE}/cv/download/${id}`, {
+      headers: {
+        ...authHeaders(),
+      },
+    });
+
+    if (response.status === 401) {
+      handleUnauthorized();
+      return;
+    }
+
+    if (!response.ok) {
+      throw new Error('CV indirilemedi.');
+    }
+
+    const blob = await response.blob();
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    const contentDisposition = response.headers.get('Content-Disposition');
+    if (contentDisposition) {
+      const matches = /filename="?([^";]+)"?/i.exec(contentDisposition);
+      if (matches && matches[1]) {
+        originalName = decodeURIComponent(matches[1]);
+      }
+    }
+    link.download = originalName || 'cv.pdf';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(url);
+  } catch (error) {
+    console.error('CV indirilemedi:', error);
+    setStatus(adminStatus, 'CV indirilemedi.', true);
+  }
+}
+
+function handleUnauthorized() {
+  setStatus(adminStatus, 'Oturumunuzun süresi doldu, lütfen tekrar giriş yapın.', true);
+  logout();
+}
+
+function logout() {
+  token = '';
+  localStorage.removeItem('adminToken');
+  updateContentForm.reset();
+  updateSection.classList.add('hidden');
+  toggleSections();
+}
+
+loginForm.addEventListener('submit', login);
+createContentForm.addEventListener('submit', createContent);
+updateContentForm.addEventListener('submit', updateContent);
+uploadCvForm.addEventListener('submit', uploadCv);
+logoutButton.addEventListener('click', logout);
+cancelUpdateButton.addEventListener('click', () => {
+  updateContentForm.reset();
+  updateSection.classList.add('hidden');
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  toggleSections();
+});


### PR DESCRIPTION
## Summary
- add an Express/MongoDB backend with JWT authentication, content CRUD, and CV upload/download endpoints
- introduce Mongoose models and authentication middleware to secure admin-only routes
- create an admin panel frontend for logging in, managing content, and handling CV uploads via the fetch API
- add project configuration files for dependencies, uploads, and repository ignores

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d65dc3f4a88325ba599903db8eafb9