### PR TITLE
Load insights page content from the API

### DIFF
--- a/models/Content.js
+++ b/models/Content.js
@@ -11,6 +11,12 @@ const contentSchema = new mongoose.Schema(
       type: String,
       required: true,
     },
+    language: {
+      type: String,
+      trim: true,
+      lowercase: true,
+      default: 'tr',
+    },
     date: {
       type: Date,
       default: Date.now,

--- a/public-site/assets/js/insights.js
+++ b/public-site/assets/js/insights.js
@@ -1,0 +1,289 @@
+(function () {
+    const API_ENDPOINT = '/api/content';
+    const visualThemes = [
+        'radial-gradient(circle at 22% 30%, rgba(255, 206, 165, 0.8) 0%, rgba(255, 206, 165, 0) 55%), radial-gradient(circle at 78% 65%, rgba(255, 126, 126, 0.45) 0%, rgba(255, 126, 126, 0) 50%), linear-gradient(150deg, #1e1f2d, #101019 58%, #2e2439)',
+        'radial-gradient(circle at 70% 30%, rgba(160, 214, 255, 0.7) 0%, rgba(160, 214, 255, 0) 55%), radial-gradient(circle at 18% 70%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(160deg, #1a2334, #0f131d 60%, #2a3245)',
+        'radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 50%), radial-gradient(circle at 78% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #141522, #1c1f31 58%, #322544)',
+        'radial-gradient(circle at 80% 20%, rgba(140, 255, 210, 0.55) 0%, rgba(140, 255, 210, 0) 55%), radial-gradient(circle at 18% 75%, rgba(255, 255, 255, 0.14) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(170deg, #101d1c, #142932 60%, #273b4a)',
+    ];
+
+    const listElement = document.getElementById('insights-list');
+    const template = document.getElementById('insight-card-template');
+    const loadingElement = document.getElementById('insights-loading');
+    const emptyElement = document.getElementById('insights-empty');
+    const errorElement = document.getElementById('insights-error');
+
+    if (!listElement || !template) {
+        return;
+    }
+
+    let cache = [];
+    let hasLoadedOnce = false;
+    let isFetching = false;
+    let hasError = false;
+
+    const setHidden = (element, hidden) => {
+        if (!element) return;
+        element.hidden = hidden;
+        element.setAttribute('data-visible', hidden ? 'false' : 'true');
+        if (hidden) {
+            element.setAttribute('aria-hidden', 'true');
+        } else {
+            element.removeAttribute('aria-hidden');
+        }
+    };
+
+    const setState = (state) => {
+        const states = {
+            loading: loadingElement,
+            empty: emptyElement,
+            error: errorElement,
+        };
+
+        Object.entries(states).forEach(([key, element]) => {
+            setHidden(element, state !== key);
+        });
+
+        hasError = state === 'error';
+    };
+
+    const normalizeLanguage = (value) => {
+        if (typeof value !== 'string') {
+            return '';
+        }
+        return value.trim().toLowerCase();
+    };
+
+    const getActiveLanguage = () => {
+        if (window.I18N && typeof window.I18N.getCurrentLanguage === 'function') {
+            return window.I18N.getCurrentLanguage();
+        }
+        return document.documentElement.lang || 'tr';
+    };
+
+    const filterByLanguage = (items, lang) => {
+        const activeLang = normalizeLanguage(lang) || 'tr';
+        return items.filter((item) => {
+            const itemLang = normalizeLanguage(item && item.language);
+            if (!itemLang || itemLang === 'multi') {
+                return true;
+            }
+            return itemLang === activeLang;
+        });
+    };
+
+    const formatDate = (dateString, lang) => {
+        if (!dateString) return '';
+        const date = new Date(dateString);
+        if (Number.isNaN(date.getTime())) {
+            return '';
+        }
+
+        const normalizedLang = normalizeLanguage(lang) || 'tr';
+        const localeMap = {
+            tr: 'tr-TR',
+            en: 'en-GB',
+        };
+        const locale = localeMap[normalizedLang] || 'tr-TR';
+
+        try {
+            return new Intl.DateTimeFormat(locale, {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+            }).format(date);
+        } catch (error) {
+            console.warn('Date formatting failed:', error);
+            return date.toLocaleString();
+        }
+    };
+
+    const stripHtml = (value) => {
+        if (typeof value !== 'string') {
+            return '';
+        }
+        return value.replace(/<[^>]*>/g, ' ');
+    };
+
+    const getExcerpt = (value, limit = 240) => {
+        const text = stripHtml(value).replace(/\s+/g, ' ').trim();
+        if (!text) {
+            return '';
+        }
+        if (text.length <= limit) {
+            return text;
+        }
+        const truncated = text.slice(0, limit).replace(/\s+\S*$/, '');
+        return `${truncated.trim()}…`;
+    };
+
+    const getLanguageLabel = (code) => {
+        const normalized = normalizeLanguage(code);
+        if (!normalized) {
+            return '';
+        }
+        if (normalized === 'multi') {
+            if (window.I18N && typeof window.I18N.translate === 'function') {
+                const multiLabel = window.I18N.translate('insights.feed.multiBadge');
+                if (multiLabel) {
+                    return multiLabel;
+                }
+            }
+            return 'TR · EN';
+        }
+        if (window.I18N && typeof window.I18N.translate === 'function') {
+            const translated = window.I18N.translate(`common.language.${normalized}`);
+            if (translated) {
+                return translated;
+            }
+        }
+        return normalized.toUpperCase();
+    };
+
+    const applyVisual = (element, index) => {
+        if (!element) return;
+        const theme = visualThemes[index % visualThemes.length];
+        element.style.backgroundImage = theme;
+    };
+
+    const render = (lang) => {
+        const items = Array.isArray(cache) ? cache : [];
+        const filtered = filterByLanguage(items, lang);
+        listElement.innerHTML = '';
+
+        if (filtered.length === 0) {
+            return 0;
+        }
+
+        filtered.forEach((content, index) => {
+            const fragment = template.content.cloneNode(true);
+            const article = fragment.querySelector('article');
+            const visual = fragment.querySelector('[data-role="visual"]');
+            const dateElement = fragment.querySelector('[data-role="date"]');
+            const languageElement = fragment.querySelector('[data-role="language"]');
+            const titleElement = fragment.querySelector('[data-role="title"]');
+            const excerptElement = fragment.querySelector('[data-role="excerpt"]');
+
+            if (article && content && content._id) {
+                article.setAttribute('data-content-id', content._id);
+            }
+
+            applyVisual(visual, index);
+
+            if (dateElement) {
+                const formattedDate = formatDate(content && (content.date || content.createdAt), lang);
+                if (formattedDate) {
+                    dateElement.textContent = formattedDate;
+                    const isoSource = content && (content.date || content.createdAt);
+                    if (isoSource) {
+                        const isoDate = new Date(isoSource);
+                        if (!Number.isNaN(isoDate.getTime())) {
+                            dateElement.setAttribute('datetime', isoDate.toISOString());
+                        }
+                    }
+                } else {
+                    dateElement.textContent = '';
+                }
+            }
+
+            if (languageElement) {
+                const label = getLanguageLabel(content && content.language);
+                if (label) {
+                    languageElement.textContent = label;
+                    languageElement.hidden = false;
+                } else {
+                    languageElement.textContent = '';
+                    languageElement.hidden = true;
+                }
+            }
+
+            if (titleElement) {
+                titleElement.textContent = (content && content.title) || '';
+            }
+
+            if (excerptElement) {
+                const excerpt = getExcerpt(content && content.body);
+                excerptElement.textContent = excerpt;
+            }
+
+            listElement.appendChild(fragment);
+        });
+
+        return filtered.length;
+    };
+
+    const fetchContents = async () => {
+        if (isFetching) {
+            return;
+        }
+        isFetching = true;
+        setState('loading');
+
+        try {
+            const response = await fetch(API_ENDPOINT, {
+                headers: {
+                    Accept: 'application/json',
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error(`Failed to load content: ${response.status}`);
+            }
+
+            const data = await response.json();
+            cache = Array.isArray(data) ? data : [];
+            hasLoadedOnce = true;
+
+            const count = render(getActiveLanguage());
+            if (count === 0) {
+                setState('empty');
+            } else {
+                setState(null);
+            }
+        } catch (error) {
+            console.error('İçerikler alınamadı:', error);
+            if (!hasLoadedOnce) {
+                listElement.innerHTML = '';
+            }
+            setState('error');
+        } finally {
+            isFetching = false;
+        }
+    };
+
+    const handleLanguageChange = (lang) => {
+        if (!hasLoadedOnce) {
+            return;
+        }
+        const count = render(lang || getActiveLanguage());
+        if (!hasError) {
+            if (count === 0) {
+                setState('empty');
+            } else {
+                setState(null);
+            }
+        }
+    };
+
+    const init = () => {
+        fetchContents();
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init, { once: true });
+    } else {
+        init();
+    }
+
+    document.addEventListener('i18n:change', (event) => {
+        handleLanguageChange(event && event.detail && event.detail.lang);
+    });
+
+    if (window.I18N && typeof window.I18N.onChange === 'function') {
+        window.I18N.onChange((lang) => {
+            handleLanguageChange(lang);
+        });
+    }
+})();

--- a/public-site/i18n/en.json
+++ b/public-site/i18n/en.json
@@ -18,7 +18,8 @@
     "langLabel": "Language",
     "language": {
       "tr": "TR",
-      "en": "EN"
+      "en": "EN",
+      "multi": "Multi"
     },
     "menuButton": "Menu",
     "nav": {
@@ -130,6 +131,12 @@
       "eyebrow": "Insights & Notes",
       "title": "Alpimimarlık Notebook",
       "body": "We collect the methods we rely on while preparing client-ready files. Short articles share notes on presentation flow, visual selection, and how our small team works."
+    },
+    "feed": {
+      "loading": "Loading notes...",
+      "empty": "No content has been published yet.",
+      "error": "We couldn’t load the articles. Please try again later.",
+      "multiBadge": "TR · EN"
     },
     "articles": {
       "lobby": {

--- a/public-site/i18n/tr.json
+++ b/public-site/i18n/tr.json
@@ -18,7 +18,8 @@
     "langLabel": "Dil Seçimi",
     "language": {
       "tr": "TR",
-      "en": "EN"
+      "en": "EN",
+      "multi": "Çok Dilli"
     },
     "menuButton": "Menü",
     "nav": {
@@ -130,6 +131,12 @@
       "eyebrow": "Görüşler & Notlar",
       "title": "Alpimimarlık Not Defteri",
       "body": "Müşterilerle paylaşılacak dosyaları hazırlarken kullandığımız yöntemleri burada toparlıyoruz. Sunum akışı, görsel seçimleri ve küçük ekibimizin çalışma biçimi hakkında notlar içeren kısa makaleler paylaşıyoruz."
+    },
+    "feed": {
+      "loading": "İçerikler yükleniyor...",
+      "empty": "Henüz paylaşılacak içerik bulunmuyor.",
+      "error": "İçerikleri yüklerken bir sorun oluştu. Lütfen daha sonra tekrar deneyin.",
+      "multiBadge": "TR · EN"
     },
     "articles": {
       "lobby": {

--- a/public-site/insights.html
+++ b/public-site/insights.html
@@ -48,6 +48,20 @@
             opacity: 0.45;
             pointer-events: none;
         }
+
+        .insights-message {
+            border-radius: 0.25rem;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(0, 0, 0, 0.4);
+            padding: 1.25rem;
+            color: rgba(255, 255, 255, 0.7);
+        }
+
+        .insights-message[data-variant='error'] {
+            border-color: rgba(248, 113, 113, 0.45);
+            background: rgba(248, 113, 113, 0.12);
+            color: #fecaca;
+        }
     </style>
 </head>
 <body class="bg-background-dark text-primary font-body antialiased">
@@ -85,61 +99,41 @@
                 Müşterilerle paylaşılacak dosyaları hazırlarken kullandığımız yöntemleri burada toparlıyoruz.
                 Sunum akışı, görsel seçimleri ve küçük ekibimizin çalışma biçimi hakkında notlar içeren kısa makaleler paylaşıyoruz.
             </p>
-            <div class="space-y-8">
-                <article class="space-y-3 border border-white/10 bg-black/30 p-6">
+            <div class="space-y-8" id="insights-feed">
+                <div class="space-y-4" id="insights-feedback">
+                    <div class="insights-message" data-visible="false" hidden id="insights-loading" role="status">
+                        <span data-i18n="insights.feed.loading">İçerikler yükleniyor...</span>
+                    </div>
+                    <div class="insights-message" data-visible="false" hidden id="insights-empty" role="status">
+                        <span data-i18n="insights.feed.empty">Henüz paylaşılacak içerik bulunmuyor.</span>
+                    </div>
                     <div
-                        aria-label="Lobi sahnesi için hazırlanan renk denemesi"
-                        class="ai-visual h-32 w-full"
-                        role="img"
-                        style="background-image: radial-gradient(circle at 22% 30%, rgba(255, 206, 165, 0.8) 0%, rgba(255, 206, 165, 0) 55%), radial-gradient(circle at 78% 65%, rgba(255, 126, 126, 0.45) 0%, rgba(255, 126, 126, 0) 50%), linear-gradient(150deg, #1e1f2d, #101019 58%, #2e2439);"
-                    ></div>
-                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="insights.articles.lobby.label">Saha Notu</p>
-                    <h2 class="text-2xl font-display text-white" data-i18n="insights.articles.lobby.title">Lobi Sunumunda İlk İzlenim</h2>
-                    <p class="text-sm text-white/70" data-i18n="insights.articles.lobby.excerpt">
-                        İlk görüşmede paylaşılan lobi sahnesi, ziyaretçilerin mekânın atmosferini hızla anlamasını sağlıyor. Bizim için çalışan üç temel dokunuşu ve örnek sunum planını anlattık.
-                    </p>
-                    <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" data-i18n="insights.articles.lobby.link" href="insight-lobi-ilk-izlenim.html">
-                        Devamını Oku
-                        <span class="material-icons ml-2 text-sm">east</span>
-                    </a>
-                </article>
-                <article class="space-y-3 border border-white/10 bg-black/30 p-6">
-                    <div
-                        aria-label="Metinsiz sahne anlatımı için kolaj"
-                        class="ai-visual h-32 w-full"
-                        role="img"
-                        style="background-image: radial-gradient(circle at 70% 30%, rgba(160, 214, 255, 0.7) 0%, rgba(160, 214, 255, 0) 55%), radial-gradient(circle at 18% 70%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(160deg, #1a2334, #0f131d 60%, #2a3245);"
-                    ></div>
-                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="insights.articles.scene.label">Rehber</p>
-                    <h2 class="text-2xl font-display text-white" data-i18n="insights.articles.scene.title">Metinsiz Sahne Nasıl Anlatılır?</h2>
-                    <p class="text-sm text-white/70" data-i18n="insights.articles.scene.excerpt">
-                        Görsel olmayan bölümler için kullandığımız üç adımlı strateji: atmosferi kelimelerle kurmak, kullanıcı hikâyesi yazmak ve son kareyi destekleyecek bir kolajla tamamlamak.
-                    </p>
-                    <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" data-i18n="insights.articles.scene.link" href="insight-metinsiz-sahne.html">
-                        Devamını Oku
-                        <span class="material-icons ml-2 text-sm">east</span>
-                    </a>
-                </article>
-                <article class="space-y-3 border border-white/10 bg-black/30 p-6">
-                    <div
-                        aria-label="Takım içi sunum oturumu için ışık denemesi"
-                        class="ai-visual h-32 w-full"
-                        role="img"
-                        style="background-image: radial-gradient(circle at 25% 70%, rgba(255, 174, 226, 0.55) 0%, rgba(255, 174, 226, 0) 50%), radial-gradient(circle at 78% 25%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(165deg, #141522, #1c1f31 58%, #322544);"
-                    ></div>
-                    <p class="text-[0.55rem] uppercase tracking-[0.55em] text-accent" data-i18n="insights.articles.sessions.label">Atölye Özeti</p>
-                    <h2 class="text-2xl font-display text-white" data-i18n="insights.articles.sessions.title">Takım İçi Konsept Oturumları</h2>
-                    <p class="text-sm text-white/70" data-i18n="insights.articles.sessions.excerpt">
-                        Haftalık oturumlarımızda kullandığımız sahne tariflerini, ışık önerilerini ve renk paleti kombinlerini örnek dosyalarla birlikte derledik.
-                    </p>
-                    <a class="inline-flex items-center text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-white" data-i18n="insights.articles.sessions.link" href="insight-konsept-oturumlari.html">
-                        Devamını Oku
-                        <span class="material-icons ml-2 text-sm">east</span>
-                    </a>
-                </article>
+                        class="insights-message"
+                        data-visible="false"
+                        data-variant="error"
+                        hidden
+                        id="insights-error"
+                        role="alert"
+                    >
+                        <span data-i18n="insights.feed.error">İçerikleri yüklerken bir sorun oluştu. Lütfen daha sonra tekrar deneyin.</span>
+                    </div>
+                </div>
+                <div aria-live="polite" class="space-y-8" id="insights-list"></div>
             </div>
         </div>
     </main>
+
+    <template id="insight-card-template">
+        <article class="space-y-4 border border-white/10 bg-black/30 p-6">
+            <div aria-hidden="true" class="ai-visual h-32 w-full" data-role="visual"></div>
+            <div class="flex items-center justify-between text-[0.55rem] uppercase tracking-[0.55em] text-accent">
+                <time data-role="date"></time>
+                <span class="text-white/40" data-role="language"></span>
+            </div>
+            <h2 class="text-2xl font-display text-white" data-role="title"></h2>
+            <p class="text-sm text-white/70" data-role="excerpt"></p>
+        </article>
+    </template>
 
     <div
         class="fixed inset-x-4 bottom-6 z-50 max-w-3xl translate-x-0 rounded border border-white/15 bg-black/90 p-6 text-sm text-white shadow-2xl md:inset-x-auto md:left-1/2 md:-translate-x-1/2"
@@ -238,6 +232,7 @@
 
     <script src="assets/js/i18n.js"></script>
     <script src="assets/js/cookie-consent.js"></script>
+    <script src="assets/js/insights.js" defer></script>
     <script>
         const menuToggle = document.getElementById('menu-toggle');
         const menuPanel = document.getElementById('menu-panel');

--- a/public/admin.html
+++ b/public/admin.html
@@ -54,6 +54,15 @@
       textarea {
         min-height: 120px;
       }
+      select {
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        border: 1px solid #d1d5db;
+        font-size: 1rem;
+        background-color: #ffffff;
+        color: inherit;
+      }
       input[type='file'] {
         padding: 0.75rem 0;
       }
@@ -147,6 +156,14 @@
               <label for="create-body">İçerik</label>
               <textarea id="create-body" name="body" required></textarea>
             </div>
+            <div>
+              <label for="create-language">Dil</label>
+              <select id="create-language" name="language">
+                <option value="tr" selected>Türkçe</option>
+                <option value="en">İngilizce</option>
+                <option value="multi">Çok Dilli</option>
+              </select>
+            </div>
             <button type="submit">Ekle</button>
           </form>
         </section>
@@ -159,6 +176,7 @@
                 <tr>
                   <th>Başlık</th>
                   <th>İçerik</th>
+                  <th>Dil</th>
                   <th>Tarih</th>
                   <th>İşlemler</th>
                 </tr>
@@ -179,6 +197,14 @@
             <div>
               <label for="update-body">İçerik</label>
               <textarea id="update-body" name="body" required></textarea>
+            </div>
+            <div>
+              <label for="update-language">Dil</label>
+              <select id="update-language" name="language">
+                <option value="tr" selected>Türkçe</option>
+                <option value="en">İngilizce</option>
+                <option value="multi">Çok Dilli</option>
+              </select>
             </div>
             <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
               <button type="submit">Güncelle</button>

--- a/public/admin.js
+++ b/public/admin.js
@@ -8,6 +8,7 @@ const updateContentForm = document.getElementById('update-content-form');
 const uploadCvForm = document.getElementById('upload-cv-form');
 const logoutButton = document.getElementById('logout-button');
 const cancelUpdateButton = document.getElementById('cancel-update');
+const createLanguageSelect = document.getElementById('create-language');
 const loginStatus = document.getElementById('login-status');
 const adminStatus = document.getElementById('admin-status');
 const contentTableBody = document.getElementById('content-table-body');
@@ -16,6 +17,27 @@ const updateSection = document.getElementById('update-section');
 const updateIdInput = document.getElementById('update-id');
 const updateTitleInput = document.getElementById('update-title');
 const updateBodyInput = document.getElementById('update-body');
+const updateLanguageSelect = document.getElementById('update-language');
+
+const LANGUAGE_LABELS = {
+  tr: 'Türkçe',
+  en: 'İngilizce',
+  multi: 'Çok Dilli',
+};
+
+const normalizeLanguageValue = (value) => {
+  if (typeof value !== 'string') {
+    return 'tr';
+  }
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return 'tr';
+  }
+  if (['tr', 'en', 'multi'].includes(normalized)) {
+    return normalized;
+  }
+  return 'tr';
+};
 
 let token = localStorage.getItem('adminToken') || '';
 
@@ -112,7 +134,7 @@ function renderContents(contents) {
   if (contents.length === 0) {
     const row = document.createElement('tr');
     const cell = document.createElement('td');
-    cell.colSpan = 4;
+    cell.colSpan = 5;
     cell.textContent = 'Henüz içerik yok.';
     row.appendChild(cell);
     contentTableBody.appendChild(row);
@@ -127,6 +149,10 @@ function renderContents(contents) {
 
     const bodyCell = document.createElement('td');
     bodyCell.textContent = content.body;
+
+    const languageCell = document.createElement('td');
+    const normalizedLanguage = normalizeLanguageValue(content.language);
+    languageCell.textContent = LANGUAGE_LABELS[normalizedLanguage] || normalizedLanguage.toUpperCase();
 
     const dateCell = document.createElement('td');
     dateCell.textContent = formatDate(content.date || content.createdAt);
@@ -150,6 +176,7 @@ function renderContents(contents) {
 
     row.appendChild(titleCell);
     row.appendChild(bodyCell);
+    row.appendChild(languageCell);
     row.appendChild(dateCell);
     row.appendChild(actionsCell);
 
@@ -197,6 +224,9 @@ async function createContent(event) {
     }
 
     createContentForm.reset();
+    if (createLanguageSelect) {
+      createLanguageSelect.value = 'tr';
+    }
     setStatus(adminStatus, 'İçerik başarıyla eklendi.');
     await fetchContents();
   } catch (error) {
@@ -210,6 +240,9 @@ function startUpdate(content) {
   updateIdInput.value = content._id;
   updateTitleInput.value = content.title || '';
   updateBodyInput.value = content.body || '';
+  if (updateLanguageSelect) {
+    updateLanguageSelect.value = normalizeLanguageValue(content.language);
+  }
   window.scrollTo({ top: updateSection.offsetTop - 20, behavior: 'smooth' });
 }
 
@@ -247,6 +280,9 @@ async function updateContent(event) {
     setStatus(adminStatus, 'İçerik güncellendi.');
     updateContentForm.reset();
     updateSection.classList.add('hidden');
+    if (updateLanguageSelect) {
+      updateLanguageSelect.value = 'tr';
+    }
     await fetchContents();
   } catch (error) {
     console.error('İçerik güncellenemedi:', error);
@@ -447,6 +483,12 @@ function logout() {
   localStorage.removeItem('adminToken');
   updateContentForm.reset();
   updateSection.classList.add('hidden');
+  if (createLanguageSelect) {
+    createLanguageSelect.value = 'tr';
+  }
+  if (updateLanguageSelect) {
+    updateLanguageSelect.value = 'tr';
+  }
   toggleSections();
 }
 
@@ -458,6 +500,9 @@ logoutButton.addEventListener('click', logout);
 cancelUpdateButton.addEventListener('click', () => {
   updateContentForm.reset();
   updateSection.classList.add('hidden');
+  if (updateLanguageSelect) {
+    updateLanguageSelect.value = 'tr';
+  }
 });
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- replace the static insights article markup with a template-driven feed container that can render API data
- add a frontend script to fetch `/api/content`, render cards with formatted dates, and surface loading/empty/error states with translation support
- extend the content model, admin panel, and translations to capture an optional language value for each insight

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d91b4d46b883258f8dcbdacd93c6eb