### PR TITLE
Add CV deletion API and admin UI controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ http://localhost:3000/admin-panel
 3. "CV Yükle" butonuna bastığınızda dosya sunucuya gönderilir, `uploads/` klasörüne kaydedilir ve veritabanına kaydı eklenir.
 4. Alt kısımda "CV Listesi" tablosu görünür. Her satırda yüklediğiniz dosyalar listelenir.
 5. "İndir" butonu dosyayı bilgisayarınıza indirir.
-6. Bir CV’yi veritabanından silmek isterseniz listedeki "Sil" butonunu kullanın (dosya da klasörden kaldırılır).
+6. Bir CV’yi silmek isterseniz listedeki "Sil" butonunu kullanın; işlem tamamlandığında tablo otomatik yenilenir ve dosya `uploads/` klasöründen de kaldırılır.
 
 ---
 
@@ -194,6 +194,7 @@ http://localhost:3000/admin-panel
   - `POST /api/upload-cv` → PDF yükler (JWT gerektirir).
   - `GET /api/cvs` → Tüm CV kayıtları (JWT gerektirir).
   - `GET /api/cv/download/:id` → CV indirme (JWT gerektirir).
+  - `DELETE /api/cv/:id` → CV kaydını ve dosyasını siler (JWT gerektirir).
 - **Güvenlik:** Parolalar `bcrypt` ile şifrelenir, tüm admin işlemleri `Authorization: Bearer <token>` başlığı ile doğrulanır.
 - **CORS:** Açık olduğu için isterseniz farklı bir domain üzerinden de API'ye erişebilirsiniz.
 

--- a/public/admin.html
+++ b/public/admin.html
@@ -226,6 +226,7 @@
 
         <section>
           <h3>CV Listesi</h3>
+          <p>Listedeki her kayıtta dosyayı indirmek veya tamamen silmek için düğmeleri kullanabilirsiniz.</p>
           <div style="overflow-x: auto;">
             <table>
               <thead>

--- a/public/admin.js
+++ b/public/admin.js
@@ -413,7 +413,14 @@ function renderCvList(cvs) {
     downloadButton.textContent = 'İndir';
     downloadButton.addEventListener('click', () => downloadCv(cv._id, cv.originalname));
 
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.textContent = 'Sil';
+    deleteButton.classList.add('danger');
+    deleteButton.addEventListener('click', () => deleteCv(cv._id, cv.originalname || cv.filename));
+
     actionsCell.appendChild(downloadButton);
+    actionsCell.appendChild(deleteButton);
 
     row.appendChild(nameCell);
     row.appendChild(typeCell);
@@ -470,6 +477,41 @@ async function downloadCv(id, originalName = 'cv.pdf') {
   } catch (error) {
     console.error('CV indirilemedi:', error);
     setStatus(adminStatus, 'CV indirilemedi.', true);
+  }
+}
+
+async function deleteCv(id, originalName = 'CV') {
+  if (!id) return;
+
+  const confirmMessage = `${originalName} dosyasını silmek istediğinize emin misiniz? Bu işlem geri alınamaz.`;
+  if (!window.confirm(confirmMessage)) {
+    return;
+  }
+
+  setStatus(adminStatus, 'CV siliniyor...');
+
+  try {
+    const response = await fetch(`${API_BASE}/cv/${id}`, {
+      method: 'DELETE',
+      headers: {
+        ...authHeaders(),
+      },
+    });
+
+    if (response.status === 401) {
+      handleUnauthorized();
+      return;
+    }
+
+    if (!response.ok) {
+      throw new Error('CV silinemedi.');
+    }
+
+    setStatus(adminStatus, 'CV silindi.');
+    await fetchCvs();
+  } catch (error) {
+    console.error('CV silinemedi:', error);
+    setStatus(adminStatus, 'CV silinemedi.', true);
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -268,6 +268,40 @@ app.get('/api/cv/download/:id', auth, async (req, res) => {
   }
 });
 
+app.delete('/api/cv/:id', auth, async (req, res) => {
+  try {
+    const cv = await CV.findById(req.params.id);
+
+    if (!cv) {
+      return res.status(404).json({ message: 'CV bulunamadı.' });
+    }
+
+    const filePath = path.join(uploadsDir, cv.filename);
+
+    try {
+      await new Promise((resolve, reject) => {
+        fs.unlink(filePath, (err) => {
+          if (!err || (err && err.code === 'ENOENT')) {
+            resolve();
+            return;
+          }
+          reject(err);
+        });
+      });
+    } catch (error) {
+      console.error('CV dosyası silinemedi:', error.message);
+      return res.status(500).json({ message: 'CV dosyası silinemedi.' });
+    }
+
+    await cv.deleteOne();
+
+    res.json({ message: 'CV silindi.' });
+  } catch (error) {
+    console.error('CV silinemedi:', error.message);
+    res.status(500).json({ message: 'Sunucu hatası.' });
+  }
+});
+
 app.get('/admin-panel', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'admin.html'));
 });


### PR DESCRIPTION
## Summary
- add an authenticated DELETE /api/cv/:id endpoint that removes the stored CV file and record
- add admin panel deletion controls with confirmation messaging and refreshed copy
- document the CV deletion workflow and API in the README and admin panel text

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68d9214d1c1c8325b99ae5e310cb561f