### PR TITLE
Remove duplicate admin panel route definition

### DIFF
--- a/server.js
+++ b/server.js
@@ -393,10 +393,6 @@ app.delete('/api/cv/:id', auth, async (req, res) => {
   }
 });
 
-app.get('/admin-panel', (req, res) => {
-  res.sendFile(path.join(__dirname, 'public', 'admin.html'));
-});
-
 app.use((err, req, res, next) => {
   console.error('Beklenmeyen hata:', err);
   res.status(500).json({ message: 'Sunucu hatası.' });


### PR DESCRIPTION
## Summary
- remove the redundant `/admin-panel` route that bypassed the required `adminBasicAuth` middleware so that only the protected handler remains

## Testing
- curl -i http://127.0.0.1:3000/admin-panel

------
https://chatgpt.com/codex/tasks/task_e_68d93c9105948325b9995ae741ce5b0d